### PR TITLE
add: util methods for use with pickle library

### DIFF
--- a/elastic/io/pickle.py
+++ b/elastic/io/pickle.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021-2022 University of Illinois
+
+import dill
+import pickle
+
+
+def is_picklable(obj):
+    return _is_picklable_raw(obj)
+
+
+def _is_picklable_raw(obj):
+    try:
+        # dumps can be slow for large objects that can be pickled
+        pickle.dumps(obj)
+    except Exception:
+        return False
+    return True
+
+
+def _is_picklable_dill(obj):
+    # compared to _is_picklable_raw, this may be faster
+    # however, dill's correctness is worrying because
+    #   it currently considers Pandas DataFrame as not
+    #   picklable, which is not true
+    return dill.pickles(obj)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+attrs==21.4.0
+dill==0.3.4
+iniconfig==1.1.1
+numpy==1.22.2
+packaging==21.3
+pandas==1.4.1
+pluggy==1.0.0
+py==1.11.0
+py4j==0.10.9.3
+pyparsing==3.0.7
+pyspark==3.2.1
+pytest==7.0.1
+python-dateutil==2.8.2
+pytz==2021.3
+six==1.16.0
+tomli==2.0.1

--- a/test/io/test_pickle.py
+++ b/test/io/test_pickle.py
@@ -1,0 +1,51 @@
+import unittest
+import numpy as np
+import pandas as pd
+import pickle
+from datetime import datetime, date
+from pyspark.sql import DataFrame, SparkSession
+
+from elastic.io.pickle import is_picklable, _is_picklable_dill
+
+class TestPickle(unittest.TestCase):
+    def test_is_picklable_numpy(self):
+        arr = np.array([1, 2, 3])
+        self.assertTrue(is_picklable(arr))
+        
+        arr_pickled = pickle.dumps(arr)
+        arr_recovered = pickle.loads(arr_pickled)
+        self.assertTrue(isinstance(arr_recovered, np.ndarray))
+        self.assertTrue(np.alltrue(arr == arr_recovered))
+        
+    def test_is_picklable_pandas(self):
+        df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+                          columns=['a', 'b', 'c'])
+        self.assertTrue(is_picklable(df))
+        
+        df_pickled = pickle.dumps(df)
+        df_recovered = pickle.loads(df_pickled)
+        self.assertTrue(isinstance(df_recovered, pd.DataFrame))
+        self.assertTrue(df_recovered.equals(df))
+    
+    # FIXME: this unit test is currently much slower than others
+    def test_is_picklable_pyspark(self):        
+        session = SparkSession.builder.getOrCreate()
+        
+        rdd = session.sparkContext.parallelize([
+            (1, 2., 'string1', date(2000, 1, 1), datetime(2000, 1, 1, 12, 0)),
+            (2, 3., 'string2', date(2000, 2, 1), datetime(2000, 1, 2, 12, 0)),
+            (3, 4., 'string3', date(2000, 3, 1), datetime(2000, 1, 3, 12, 0))
+        ])
+        df = session.createDataFrame(rdd, schema=['a', 'b', 'c', 'd', 'e'])
+        self.assertFalse(is_picklable(df))
+        
+        # df_pickled = pickle.dumps(df)
+        # df_recovered = pickle.loads(df_pickled)
+        # self.assertTrue(isinstance(df_recovered, DataFrame))
+        # self.assertEqual(df_recovered.schema, df.schema)
+        # self.assertEqual(df_recovered.collect(), df.collect())
+        
+        session.stop()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Description:
- Adds `is_picklable` method that can be used to check if a Python object can be pickled
- `dill` is an alternative that was considered. It is not adopted because it appears to be not correct (e.g. with respect to the unit test for Pandas DataFrame)

Tests:
- Unit tests (numpy array, pandas df, pyspark df)

Resolves #2