### PR TITLE
add: impl for resume related methods

### DIFF
--- a/elastic/common/migration_metadata.py
+++ b/elastic/common/migration_metadata.py
@@ -4,30 +4,38 @@
 # Copyright 2021-2022 University of Illinois
 
 KEY_OBJECTS_MIGRATED = "objectsMigrated"
-KEY_RECOMPUTE_SEQUENCE = "recomputeSequence"
+KEY_RECOMPUTE_CODE = "recomputeCode"
 
 class MigrationMetadata:
     def __init__(self):
         pass
 
 
-    def with_objects_migrated(self, objects: list):
+    def with_objects_migrated(self, objects: dict):
         self.objects_migrated = objects
         return self
 
 
-    def with_recompute_seq(self, recompute: list):
-        self.recompute_seq = recompute
+    def get_objects_migrated(self):
+        return self.objects_migrated
+
+
+    def with_recompute_code(self, recompute: list):
+        self.recomputeCode = recompute
+
+
+    def get_recompute_code(self):
+        return self.recomputeCode
 
 
     def to_json(self):
         return {
             "objectsMigrated": self.objects_migrated,
-            "recomputeSequence": self.recompute_seq
+            "recomputeCode": self.recomputeCode
         }
 
 
     @staticmethod
     def from_json(kv: dict):
         return MigrationMetadata().with_objects_migrated(kv[KEY_OBJECTS_MIGRATED])\
-                                  .with_recompute_seq(KEY_RECOMPUTE_SEQUENCE)
+                                  .with_recompute_code(KEY_RECOMPUTE_CODE)


### PR DESCRIPTION
Description:
- One notable change is that we modified the structure of the migration metadata to this new format
  - The migrated objects field will now be a map from object path in storage to a list of all object names that refer to it
  - The recomputation code field will now simply point to a file in storage that contains all code needed for the entire recomputation (instead of sequence).

Testing
- Will be done as part of benchmarking #11 

Resolves #10 