### PR TITLE
Migrate over standard Python watchdog

### DIFF
--- a/kishu/examples/target_longrunning.py
+++ b/kishu/examples/target_longrunning.py
@@ -1,0 +1,43 @@
+"""Example of a long-running script.""" 
+
+def a():
+    cnt_a = 0
+    for adx in range(1000):
+        cnt_a += adx
+    return cnt_a
+
+
+def a2():
+    cnt_a = 0
+    for adx in range(1000):
+        cnt_a += adx
+    return cnt_a
+
+
+def b(bi=3):
+    if bi > 0:
+        return b(bi - 1)
+    cnt_b = 0
+    for bdx in range(1000):
+        cnt_b += a()
+    for bdx in range(1000):
+        cnt_b += a2()
+    return cnt_b
+
+
+def c():
+    cnt_c = 0
+    for cdx in range(1000):
+        cnt_c += b()
+    return cnt_c
+
+
+def d():
+    cnt_d = 0
+    for ddx in range(1000):
+        cnt_d += c()
+        print(ddx)
+    return cnt_d
+
+# print(locals())
+print(d())

--- a/kishu/kishu/capture.py
+++ b/kishu/kishu/capture.py
@@ -1,0 +1,676 @@
+"""
+Capture Python state.
+
+To use the watchdog on target program:
+    python kishu/capture.py [watchdog_args] [target_program [args]]
+
+Help:
+    python kishu/capture.py -h
+
+Examples:
+    python kishu/capture.py examples/target_longrunning.py
+    python kishu/capture.py --verbosity=2 examples/target_longrunning.py
+    python kishu/capture.py --cpu-sampling-rate=10.0 examples/target_longrunning.py
+"""
+import argparse
+import atexit
+import contextlib
+import dill as pickle
+import gc
+import importlib
+import multiprocessing
+import os
+import re
+import signal
+import sys
+import time
+import traceback
+from importlib.abc import SourceLoader
+from importlib.machinery import ModuleSpec
+from loguru import logger
+from types import CodeType, FrameType
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from kishu.delta import StateDelta
+from kishu.exceptions import TypeNotSupportedError
+from kishu.state import State
+
+
+"""
+Standard Python captures
+"""
+
+
+class StandardPythonCapture:
+    @staticmethod
+    def capture_state(
+        depth: int = 0,
+        truncate_at_frame_id: int = -1,
+    ) -> Tuple[State, List[bool]]:
+        """
+        Capture stack of frames starting at the caller location. Return the state and list of
+        booleans indicating whether the frame has been captured before.
+
+        Specify depth to capture at deeper (depth < 0) or shallower (depth > 0) frames.
+
+        WARNING: Caller must delete frames to avoid memory leaks.
+        """
+        raw_frames = None
+        try:
+            raw_frames, same_frames = StandardPythonCapture._capture_raw_frames(
+                depth=depth + 1,
+                truncate_at_frame_id=truncate_at_frame_id,
+            )
+            assert len(raw_frames) == len(same_frames)
+            state = State.parse_from(raw_frames)
+        finally:
+            del raw_frames
+
+        """
+        Both state and same_frames have the same length. Each boolean in same_frames is true when
+        the frame has been captured through StandardPythonCapture previously. Note that using
+        id(frame) is unreliable as the address can (often) be reused.
+        """
+        return state, same_frames
+
+    @staticmethod
+    def _capture_raw_frames(
+        depth: int = 0,
+        truncate_at_frame_id: int = -1,
+    ) -> Tuple[List[FrameType], List[bool]]:
+        """
+        Capture stack of frames where caller is at depth=0. Return frames and list of boolean
+        indicating whether each frame has been seen.
+
+        WARNING: Caller must delete frames to avoid memory leaks.
+
+        Refer to https://docs.python.org/3/library/inspect.html about frame objects.
+        """
+        raw_frame: Optional[FrameType] = sys._getframe(1)
+        assert raw_frame is not None, 'This Python interpreter does not support currentframe.'
+        try:
+            raw_frames = []
+            while raw_frame is not None and id(raw_frame) != truncate_at_frame_id and depth > 0:
+                raw_frame = raw_frame.f_back
+                depth -= 1
+            while raw_frame is not None and id(raw_frame) != truncate_at_frame_id:
+                raw_frames.append(raw_frame)
+                raw_frame = raw_frame.f_back
+        finally:
+            del raw_frame
+        return raw_frames, StandardPythonCapture._breadcrumb(raw_frames)
+
+    @staticmethod
+    def _breadcrumb(raw_frames: List[FrameType]) -> List[bool]:
+        same_frames = [raw_frame.f_trace is not None for raw_frame in raw_frames]
+        for raw_frame in raw_frames:
+            raw_frame.f_trace = StandardPythonCapture._frame_breadcrumb
+        return same_frames
+
+    @staticmethod
+    def _frame_breadcrumb(frame, event, arg):
+        """
+        Dummy function installed as a trace to track which frame has been seen.
+        """
+        pass
+        return StandardPythonCapture._frame_breadcrumb
+
+
+"""
+Execute target code and passively periodically capture frames.
+
+Initial structure is inspired by scalene.
+"""
+class WatchdogArguments(argparse.Namespace):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cpu_sampling_delay = 1.0  # sec
+        self.cpu_sampling_rate = 1.0  # sec/sample
+
+        self.capture_delta_file = None  # file path
+        self.capture_metrics_file = None  # file path
+        self.logger_file = None  # file path
+
+        self.verbosity = 0  # higher = more prints
+
+
+class WatchdogSignals:
+    def __init__(self) -> None:
+        assert sys.platform != "win32"
+        self.cpu_timer_signal = signal.ITIMER_VIRTUAL
+        self.cpu_signal = signal.SIGVTALRM
+        self.start_profiling_signal = signal.SIGILL
+        self.stop_profiling_signal = signal.SIGBUS
+        self.memcpy_signal = signal.SIGPROF
+        self.malloc_signal = signal.SIGXCPU
+        self.free_signal = signal.SIGXFSZ
+        self.interrupt_signal = signal.SIGINT 
+
+
+class WatchdogCaptureMetrics:
+    def __init__(self) -> None:
+        """
+        For experimental purposes only. Should use better measures/counters instead.
+        """
+        self.columns: Dict[str, List[Any]] = {}
+
+    def record(self, **kwargs: Dict[str, Any]) -> None:
+        for key, value in kwargs.items():
+            self.columns.setdefault(key, []).append(value)
+
+    def save_to(self, filename: str, delimiter: str=",", newline: str="\n"):
+        with open(filename, "w") as f:
+            for key, values in self.columns.items():
+                f.write(key)
+                for value in values:
+                    f.write(delimiter)
+                    f.write(str(value))
+                f.write(newline)
+
+
+class Watchdog:
+    """
+    A capture management that instruments the target application and calls capture methods.
+
+    Initially, it parses its command-line arguments, setup Python environment for the target, and
+    execute the target application.
+
+    Currently, it periodically captures application's state using system alarm clock. This clock
+    only tracks Python execution time and ignores those times in extensions.
+
+    It is implemented as a singleton using attributes and static methods to reduce overheads.
+      - Class attributes
+      - Arguments
+      - Signals
+      - Signal handlers
+      - Explicit imports
+      - Capture function (capture_state)
+      - Execution (exec_capture)
+      - Instrumentation (launch_exec_capture)
+    """
+
+
+    """Class Attributes"""
+
+    # Configuration
+    __capture_core = StandardPythonCapture
+    __signals = WatchdogSignals()
+    __args = WatchdogArguments()
+
+    # Target program metadata
+    __program_path: str = ""
+    __program_being_profiled: str = ""
+    __exec_capture_frame_id: int = -1  # uninitialized
+
+    # State tracking
+    __previous_program_state: State = State([])
+
+    # System calls
+    __orig_signal = signal.signal
+    __orig_setitimer = signal.setitimer
+    __orig_siginterrupt = signal.siginterrupt
+
+    # Experimental properties
+    __capture_metrics = WatchdogCaptureMetrics()
+    __capture_id = 0
+
+
+    """Class Attributes"""
+
+    @staticmethod
+    def parse_args(argv: List[str] = []) -> Tuple[WatchdogArguments, List[str]]:
+        defaults = WatchdogArguments()
+        parser = argparse.ArgumentParser(
+            prog="Watchdog to capture target program's state.",
+            allow_abbrev=False,
+        )
+        parser.add_argument(
+            "--cpu-sampling-delay",
+            dest="cpu_sampling_delay",
+            type=float,
+            default=defaults.cpu_sampling_delay,
+            help=f"CPU sampling initial delay (default: {defaults.cpu_sampling_rate})",
+        )
+        parser.add_argument(
+            "--cpu-sampling-rate",
+            dest="cpu_sampling_rate",
+            type=float,
+            default=defaults.cpu_sampling_rate,
+            help=f"CPU sampling rate (default: {defaults.cpu_sampling_rate})",
+        )
+        parser.add_argument(
+            "--capture-delta-file",
+            dest="capture_delta_file",
+            type=str,
+            default=defaults.capture_delta_file,
+            help="Path to save capture delta",
+        )
+        parser.add_argument(
+            "--capture-metrics-file",
+            dest="capture_metrics_file",
+            type=str,
+            default=defaults.capture_metrics_file,
+            help="Path to save capture metrics",
+        )
+        parser.add_argument(
+            "--logger-file",
+            dest="logger_file",
+            type=str,
+            default=defaults.logger_file,
+            help="Path to log file",
+        )
+        parser.add_argument(
+            "--verbosity",
+            dest="verbosity",
+            type=int,
+            default=defaults.verbosity,
+            help=f"Verbosity (higher for more logs, default: {defaults.verbosity})",
+        )
+        args, left = parser.parse_known_args(args=argv)
+        args = cast(WatchdogArguments, args)
+        return args, left
+
+    @staticmethod
+    def process_args(args: WatchdogArguments) -> None:
+        Watchdog.__args = args
+
+
+    """Signals"""
+
+    @staticmethod
+    def _enable_signals() -> None:
+        assert sys.platform != "win32"
+        Watchdog.__orig_signal(
+            Watchdog.__signals.cpu_signal,
+            Watchdog._cpu_signal_handler,
+        )
+        Watchdog._set_alarm(Watchdog.__args.cpu_sampling_delay)
+
+    @staticmethod
+    def _set_alarm(duration_s: float) -> None:
+        Watchdog.__orig_setitimer(
+            Watchdog.__signals.cpu_timer_signal,
+            duration_s,
+        )
+
+    @staticmethod
+    def _disable_signals() -> None:
+        assert sys.platform != "win32"
+        Watchdog.__orig_setitimer(Watchdog.__signals.cpu_timer_signal, 0)
+
+    @staticmethod
+    def start() -> None:
+        Watchdog._enable_signals()
+
+    @staticmethod
+    def stop() -> None:
+        Watchdog._disable_signals()
+
+
+    """Signal Handlers"""
+
+    @staticmethod
+    def _exit_handler() -> None:
+        Watchdog.stop()
+
+    @staticmethod
+    def _interruption_handler(
+        signum: Union[
+            Callable[[signal.Signals, FrameType], None],
+            int,
+            signal.Handlers,
+            None,
+        ],
+        this_frame: Optional[FrameType],
+    ) -> None:
+        raise KeyboardInterrupt
+
+    @staticmethod
+    def _cpu_signal_handler(
+        signum: Union[
+            Callable[[signal.Signals, FrameType], None],
+            int,
+            signal.Handlers,
+            None,
+        ],
+        this_frame: Optional[FrameType],
+    ) -> None:
+        # Capture all states to a storage.
+        Watchdog.capture_state(depth=1)
+
+        # Set alarm for next signal.
+        # TODO: Adaptive sampling.
+        # TODO: Compensate for time drift.
+        Watchdog._set_alarm(Watchdog.__args.cpu_sampling_rate)
+
+
+    """Explicit Imports"""
+
+    @staticmethod
+    def _strip_argv_if_module() -> bool:
+        if len(sys.argv) >= 2 and sys.argv[0] == "-m":
+            # Remove -m and the provided module name
+            _, mod_name, *sys.argv = sys.argv
+
+            # Given `some.module`, find the path of the corresponding
+            # some/module/__main__.py or some/module.py file to run.
+            _, spec, _ = Watchdog._get_module_details(mod_name)
+            if not spec.origin:
+                raise FileNotFoundError
+
+            # Prepend the found .py file to arguments
+            sys.argv.insert(0, spec.origin)
+
+            return True
+        else:
+            return False
+
+    @staticmethod
+    def _get_module_details(
+        mod_name: str,
+        error: Type[Exception] = ImportError,
+    ) -> Tuple[str, ModuleSpec, CodeType]:
+        """Copy of `runpy._get_module_details`, but not private."""
+        if mod_name.startswith("."):
+            raise error("Relative module names not supported")
+        pkg_name, _, _ = mod_name.rpartition(".")
+        if pkg_name:
+            # Try importing the parent to avoid catching initialization errors
+            try:
+                __import__(pkg_name)
+            except ImportError as e:
+                # If the parent or higher ancestor package is missing, let the
+                # error be raised by find_spec() below and then be caught. But do
+                # not allow other errors to be caught.
+                if e.name is None or (
+                    e.name != pkg_name and not pkg_name.startswith(e.name + ".")
+                ):
+                    raise
+            # Warn if the module has already been imported under its normal name
+            existing = sys.modules.get(mod_name)
+            if existing is not None and not hasattr(existing, "__path__"):
+                from warnings import warn
+
+                msg = (
+                    "{mod_name!r} found in sys.modules after import of "
+                    "package {pkg_name!r}, but prior to execution of "
+                    "{mod_name!r}; this may result in unpredictable "
+                    "behaviour".format(mod_name=mod_name, pkg_name=pkg_name)
+                )
+                warn(RuntimeWarning(msg))
+
+        try:
+            spec = importlib.util.find_spec(mod_name)
+        except (ImportError, AttributeError, TypeError, ValueError) as ex:
+            # This hack fixes an impedance mismatch between pkgutil and
+            # importlib, where the latter raises other errors for cases where
+            # pkgutil previously raised ImportError
+            msg = "Error while finding module specification for {!r} ({}: {})"
+            if mod_name.endswith(".py"):
+                msg += (
+                    f". Try using '{mod_name[:-3]}' instead of "
+                    f"'{mod_name}' as the module name."
+                )
+            raise error(msg.format(mod_name, type(ex).__name__, ex)) from ex
+        if spec is None:
+            raise error("No module named %s" % mod_name)
+        if spec.submodule_search_locations is not None:
+            if mod_name == "__main__" or mod_name.endswith(".__main__"):
+                raise error("Cannot use package as __main__ module")
+            try:
+                pkg_main_name = mod_name + ".__main__"
+                return Watchdog._get_module_details(pkg_main_name, error)
+            except error as e:
+                if mod_name not in sys.modules:
+                    raise  # No module loaded; being a package is irrelevant
+                raise error(
+                    ("%s; %r is a package and cannot " + "be directly executed")
+                    % (e, mod_name)
+                )
+        loader = spec.loader
+        # use isinstance instead of `is None` to placate mypy
+        if not isinstance(loader, SourceLoader):
+            raise error(
+                "%r is a namespace package and cannot be executed" % mod_name
+            )
+        try:
+            code = loader.get_code(mod_name)
+        except ImportError as e:
+            raise error(format(e)) from e
+        if code is None:
+            raise error("No code object available for %s" % mod_name)
+        return mod_name, spec, code
+
+    @staticmethod
+    def _get_executable() -> str:
+        # Look for something ending in '.py'.
+        progs = [x for x in sys.argv if re.match(r".*\.py$", x)]
+        # Just in case that didn't work, try sys.argv[0] and __file__.
+        with contextlib.suppress(Exception):
+            progs.extend((sys.argv[0], __file__))
+        if not progs:
+            raise FileNotFoundError
+
+        # Treat the first one as our executable.
+        return progs[0]
+
+    def __init__(self, args: WatchdogArguments) -> None:
+        assert sys.platform != "win32"
+        # Register the exit handler to run when the program terminates or we quit.
+        atexit.register(Watchdog._exit_handler)
+
+
+    """Capture Function"""
+
+    @staticmethod
+    def capture_state(depth=0) -> None:
+        # EXPERIMENT: Counters and metrics
+        start_time = time.perf_counter()
+        capture_id = Watchdog.__capture_id
+        timestamp = time.time()
+        state_size = -1
+        state_delta_size = -1
+        time_elapsed: float = -1
+        Watchdog.__capture_id += 1
+
+        program_state = None
+        try:
+            # Capture state
+            program_state, same_frames = Watchdog.__capture_core.capture_state(
+                depth=depth+1,
+                truncate_at_frame_id=Watchdog.__exec_capture_frame_id,
+            )
+            if Watchdog.__args.verbosity >= 2:
+                logger.info(f"{program_state}")
+
+            # Find delta
+            state_delta = StateDelta.delta(
+                Watchdog.__previous_program_state,
+                program_state,
+                same_frames,
+            )
+            state_delta_bytes = pickle.dumps(state_delta)
+            state_delta_size = len(state_delta_bytes)
+            if Watchdog.__args.verbosity >= 2:
+                logger.info(f"{state_delta}")
+            logger.info(f"Found delta having {state_delta_size} bytes")
+
+            # Persist delta
+            if Watchdog.__args.capture_delta_file is not None:
+                with open(Watchdog.__args.capture_delta_file, "wb") as fdelta:
+                    fdelta.write(state_delta_bytes)
+                    fdelta.flush()
+                    os.fsync(fdelta)
+                logger.info(f"Persisted delta at {Watchdog.__args.capture_delta_file}")
+
+            # Step forward
+            Watchdog.__previous_program_state = program_state
+        except TypeNotSupportedError as e:
+            logger.error(f"Failed to capture frames. {e}")
+            pass
+        except (TypeError, NotImplementedError, pickle.PicklingError) as e:
+            logger.error(f"Failed to pickle state. {e}")
+            pass
+        except AttributeError as e:
+            logger.exception(f"Faulty pickle serialization. {e}")
+            pass
+        except KeyboardInterrupt:
+            logger.info("Watchdog execution interrupted during _cpu_signal_handler.")
+            raise
+        finally:
+            del program_state
+
+        # EXPERIMENT: Final counters and record
+        end_time = time.perf_counter()
+        time_elapsed = end_time - start_time
+        if Watchdog.__args.capture_metrics_file is not None:
+            Watchdog.__capture_metrics.record(
+                capture_id=capture_id,
+                timestamp=timestamp,
+                state_size=state_size,
+                state_delta_size=state_delta_size,
+                time_elapsed=time_elapsed,
+            )
+        logger.info(f'Captured in {time_elapsed:.6f} seconds')
+
+
+    """Execution"""
+
+    def exec_capture(
+        self,
+        code: str,
+        the_globals: Dict[str, str],
+        the_locals: Dict[str, str],
+    ) -> Union[str, int, None]:
+        # Run the code being profiled.
+        Watchdog.__exec_capture_frame_id = id(sys._getframe())
+        exit_status: Union[str, int, None] = 0
+        self.start()
+        try:
+            exec(code, the_globals, the_locals)
+        except SystemExit as se:
+            # Intercept sys.exit and propagate the error code.
+            exit_status = se.code
+        except KeyboardInterrupt:
+            # Cleanly handle keyboard interrupts (quits execution and dumps the profile).
+            logger.info("Watchdog execution interrupted.")
+        except Exception as e:
+            logger.error(f"Error in program being captured:\n {e}")
+            traceback.print_exc()
+            exit_status = 1
+        finally:
+            self.stop()
+        return exit_status
+
+
+    """Instrumentation"""
+
+    @staticmethod
+    def launch_exec_capture(
+        args: WatchdogArguments,
+        target_args: List[str],
+    ) -> None:
+        # Setup signal handler
+        assert sys.platform != "win32"
+        Watchdog.__orig_signal(
+            Watchdog.__signals.interrupt_signal, Watchdog._interruption_handler
+        )  # To insert additional step(s) at interruption time (e.g., ctrl-c)
+
+        # Execute target code
+        sys.argv = target_args
+        with contextlib.suppress(Exception):
+            multiprocessing.set_start_method("fork")
+        try:
+            Watchdog.process_args(args)
+            prog = None
+            exit_status: Union[str, int, None] = 0
+            try:
+                module = Watchdog._strip_argv_if_module()
+                prog = Watchdog._get_executable()
+                logger.info(f"Detected target program \"{prog}\" with arguments \"{target_args}\"")
+
+                with open(prog, "r") as prog_being_profiled:
+                    # Read in the code and compile it.
+                    code: Any = ""
+                    try:
+                        code_str = prog_being_profiled.read()
+                        code = compile(code_str, prog, "exec")
+                    except SyntaxError:
+                        traceback.print_exc()
+                        sys.exit(1)
+
+                    # Push the program's path.
+                    program_path = os.path.dirname(os.path.abspath(prog))
+                    if not module:
+                        sys.path.insert(0, program_path)
+
+                    # If a program path was specified at the command-line, use it.
+                    Watchdog.__program_path = os.getcwd()
+                    Watchdog.__program_being_profiled = prog
+                    # Grab local and global variables.
+                    import __main__
+                    the_locals: Dict[str, Any] = {}
+                    the_globals = the_locals
+                    # Splice in the name of the file being executed instead of the profiler.
+                    the_globals["__file__"] = os.path.abspath(prog)
+                    # Some mysterious module foo to make this work the same with -m as with `Watchdog`.
+                    the_globals["__spec__"] = None
+                    # Insert same builtins.
+                    the_globals["__builtins__"] = __main__.__dict__["__builtins__"]
+                    # Set target program as main.
+                    the_globals["__name__"] = "__main__"
+                    # Do a GC before we start.
+                    gc.collect()
+                    # Start the profiler.
+                    profiler = Watchdog(args)
+                    try:
+                        # We exit with this status (returning error code as appropriate).
+                        exit_status = profiler.exec_capture(code, the_locals, the_globals)
+                        sys.exit(exit_status)
+                    except AttributeError:
+                        # don't let the handler below mask programming errors
+                        raise
+                    except Exception as ex:
+                        logger.error(
+                            f"Watchdog: An exception of type {type(ex).__name__} occurred. "
+                            f"Arguments:\n{ex.args}"
+                        )
+                        logger.error(traceback.format_exc())
+            except (FileNotFoundError, IOError):
+                if prog:
+                    logger.error(f"Watchdog: could not find input file {prog}")
+                else:
+                    logger.error("Watchdog: no input file specified.")
+                sys.exit(1)
+        except SystemExit:
+            pass
+        except Exception:
+            logger.error(f"Watchdog failed to initialize.\n{traceback.format_exc()}")
+            sys.exit(1)
+        finally:
+            if args.capture_metrics_file is not None:
+                Watchdog.__capture_metrics.save_to(args.capture_metrics_file)
+                logger.info(f"Save capture metrics to {args.capture_metrics_file}")
+            sys.exit(exit_status)
+
+    @staticmethod
+    def main(args: List[str]) -> None:
+        watchdog_args, target_args = Watchdog.parse_args(args)
+        logger.info(f"Args: {watchdog_args}")
+        if watchdog_args.logger_file is not None:
+            logger.add(watchdog_args.logger_file)
+        Watchdog.launch_exec_capture(watchdog_args, target_args)
+
+
+if __name__ == "__main__":
+    Watchdog.main(sys.argv)

--- a/kishu/kishu/delta.py
+++ b/kishu/kishu/delta.py
@@ -1,0 +1,185 @@
+"""
+Delta from one state to another.
+"""
+from __future__ import annotations
+
+import dill as pickle
+from typing import List, Set, Tuple
+
+from kishu.state import Cells, ContinuousPickler, Execution, SerializedCells, State
+
+
+"""
+Control flags/constants
+"""
+PRINT_CELL_SIZE = False
+
+
+"""
+StateDelta = List[ScopeCellsDelta], consisting of
+- The differences from older scope cells to newer scope cells
+- The newer execution states
+"""
+class ScopeCellsDelta:
+    """
+    Represent differences from a scope cell to another with WRITE and DELETE deltas.
+    - WRITE: a cell is new or has changed.
+    - DELETE: a cell is deleted.
+    """
+
+    def __init__(self, added: SerializedCells, deleted: Set[str], execution: Execution) -> None:
+        self.added = added  # Added/overwrite cells.
+        self.deleted = deleted  # Deleted cells.
+        self.execution = execution  # Execution state
+        
+    @staticmethod
+    def _from_to(
+        from_cells: SerializedCells,
+        to_cells: SerializedCells,
+        execution: Execution,
+    ) -> ScopeCellsDelta:
+        """
+        Find delta on a pair of cells.
+        """
+        # Extracted new cells or modified cells (WRITE).
+        added = {}
+        for key, to_cells_value in to_cells.items():
+            if key not in from_cells or from_cells[key] != to_cells_value:
+                added[key] = to_cells_value
+
+        # Extract missing cells (DELETE).
+        deleted = set(from_cells) - set(to_cells)
+
+        return ScopeCellsDelta(
+            added=added,
+            deleted=deleted,
+            execution=execution,
+        )
+
+    @staticmethod
+    def _from_to_different(
+        from_cells: SerializedCells,
+        to_cells: SerializedCells,
+        execution: Execution,
+    ) -> ScopeCellsDelta:
+        """
+        Find delta on a pair of cells from totally different scopes.
+        """
+        return ScopeCellsDelta(
+            added=to_cells,
+            deleted=set(from_cells) - set(to_cells),
+            execution=execution,
+        )
+
+    def get_added(self):
+        return self.added
+
+    def get_deleted(self):
+        return self.deleted
+
+    def get_execution(self):
+        return self.execution
+
+    def __repr__(self) -> str:
+        if PRINT_CELL_SIZE:
+            added_list = str([(key, len(value)) for key, value in self.added.items()])
+        else:
+            added_list = str(list(self.added))
+        return 'ScopeCellsDelta(' \
+            f'added= {added_list}, ' \
+            f'deleted= {self.deleted}, ' \
+            f'execution= {self.execution}' \
+            f')'
+
+
+class StateDelta:
+    def __init__(self, scope_deltas: List[ScopeCellsDelta]) -> None:
+        self.scope_deltas = scope_deltas
+
+    @staticmethod
+    def delta(from_state: State, to_state: State, same_frames: List[bool]) -> StateDelta:
+        """
+        Find delta on a pair of states
+        """
+        # TODO: reuse last extraction to extract only once per state.
+        from_scope_state, _ = StateDelta._extract_scope_state(from_state)
+        to_scope_state, to_executions = StateDelta._extract_scope_state(to_state)
+        scope_deltas = StateDelta._delta_scope_state(
+            from_scope_state=from_scope_state,
+            to_scope_state=to_scope_state,
+            to_executions=to_executions,
+            same_frames=same_frames,
+        )
+        return StateDelta(scope_deltas=scope_deltas)
+
+    @staticmethod
+    def _extract_scope_state(state: State) -> Tuple[List[SerializedCells], List[Execution]]:
+        # Use this pickler to combine share objects
+        pickler = ContinuousPickler()
+
+        # In reverse frame-key order to keep reference stable and so increase chance of equality.
+        scope_state = []
+        executions = []
+        for frame in reversed(state.get_frames()):
+            cells: Cells = frame.get_cells()
+            execution: Execution = frame.get_execution()
+            scope_state.append({key: pickler.dumps(cells[key]) for key in sorted(cells)})
+            executions.append(execution)
+        return scope_state[::-1], executions[::-1]
+
+    @staticmethod
+    def _delta_scope_state(
+        from_scope_state: List[SerializedCells],
+        to_scope_state: List[SerializedCells],
+        to_executions: List[Execution],
+        same_frames: List[bool],
+
+    ) -> List[ScopeCellsDelta]:
+        assert len(to_scope_state) == len(same_frames)
+        assert len(same_frames) == 1 or all(
+            same_frames[idx] and not same_frames[idx+1] for idx in range(len(same_frames)-1)
+        )
+
+        # Reverse frame order assuming base frame is at the end.
+        from_scope_state = from_scope_state[::-1]
+        to_scope_state = to_scope_state[::-1]
+        same_frames = same_frames[::-1]
+
+        # Iterate on common frames.
+        diff = []
+        for f_idx in range(len(to_scope_state)):
+            from_scope_cells = {} if f_idx >= len(from_scope_state) else from_scope_state[f_idx]
+            to_scope_cells = to_scope_state[f_idx]
+            execution = to_executions[f_idx]
+            same_frame = same_frames[f_idx]
+            if same_frame:
+                diff.append(ScopeCellsDelta._from_to(
+                    from_cells=from_scope_cells,
+                    to_cells=to_scope_cells,
+                    execution=execution,
+                ))
+            else:
+                diff.append(ScopeCellsDelta._from_to_different(
+                    from_cells=from_scope_cells,
+                    to_cells=to_scope_cells,
+                    execution=execution,
+                ))
+
+        # Mark the rest of frames as deleted.
+        for f_idx in range(len(to_scope_state), len(from_scope_state)):
+            diff.append(ScopeCellsDelta._from_to_different(
+                from_cells=from_scope_cells,
+                to_cells={},
+                execution=execution,
+            ))
+
+        # Flip frame order back.
+        return diff[::-1]
+
+    def get_scope_deltas(self):
+        return self.scope_deltas
+
+    def __repr__(self) -> str:
+        scope_deltas_str = '\n'.join([scope_delta.__repr__() for scope_delta in self.scope_deltas])
+        scope_deltas_str = scope_deltas_str.replace('\n', '\n\t')
+        return f'StateDelta(\n\t{scope_deltas_str}\n)'

--- a/kishu/kishu/exceptions.py
+++ b/kishu/kishu/exceptions.py
@@ -1,0 +1,6 @@
+"""
+Raised by state
+"""
+class TypeNotSupportedError(Exception):
+    def __init__(self, type_name, var_name, var_value):
+        super().__init__(f'{type_name} not yet supported ({var_name, var_value}).')

--- a/kishu/kishu/state.py
+++ b/kishu/kishu/state.py
@@ -1,0 +1,348 @@
+"""Classes that define a state."""
+from __future__ import annotations
+
+import dill as pickle
+import os
+import types
+from io import BytesIO
+from types import CodeType, FrameType
+from typing import Any, Dict, Iterator, List, Set, Union
+
+from kishu.exceptions import TypeNotSupportedError
+
+
+"""
+Control flags/constants
+"""
+PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL
+PRINT_CELL_SIZE = False
+
+
+"""
+Convenience types
+"""
+Cells = Dict[str, Any]  # Mapping from variable names to their objects.
+SerializedCells = Dict[str, bytes]  # Mapping from variable names to their serialized objects.
+
+
+class ContinuousPickler:
+    """
+    Pickler that memorizes shared reference across multiple dumps.
+
+        pickler = ContinuousPickler()
+        pickler.dumps(obj_1)
+        pickler.dumps(obj_2)
+        ...
+    """
+
+    def __init__(self):
+        """Constructor."""
+        self.bytes_io = BytesIO()
+        self.pickler = pickle.Pickler(
+            file=self.bytes_io,
+            protocol=PICKLE_PROTOCOL,
+        )
+
+    def dumps(self, obj):
+        """Serialize object possibly with previous shared reference."""
+        self.pickler.dump(obj)
+        pickled_value = self.bytes_io.getvalue()
+
+        # Reset the buffer
+        self.bytes_io.seek(0)
+        self.bytes_io.truncate()
+
+        return pickled_value
+
+
+"""
+The following are classes defining a state in order from lowest to highest level.
+  1. Frame = Scope + Code + Execution
+  2. State = List[Frame]
+"""
+
+
+class Scope:
+    """A scope is a set of visible variables."""
+
+    def __init__(self, cells: Cells) -> None:
+        """Constructor."""
+        self.cells: Cells = cells
+
+    @staticmethod
+    def parse_from(raw_scope: Dict[str, Any]) -> Scope:
+        """
+        Parse Python's scope dictionary into serializable object.
+        """
+        cells: Dict[str, Any] = {}
+        for var_name, var_value in raw_scope.items():
+            # Here we list all primitive types to be enabled as we develop.
+            if isinstance(var_value, types.FunctionType):
+                cells[var_name] = var_value
+            elif isinstance(var_value, types.LambdaType):
+                raise TypeNotSupportedError('LambdaType', var_name, var_value)
+            elif isinstance(var_value, types.GeneratorType):
+                raise TypeNotSupportedError('GeneratorType', var_name, var_value)
+            elif isinstance(var_value, types.CoroutineType):
+                raise TypeNotSupportedError('CoroutineType', var_name, var_value)
+            elif isinstance(var_value, types.AsyncGeneratorType):
+                raise TypeNotSupportedError('AsyncGeneratorType', var_name, var_value)
+            elif isinstance(var_value, types.CodeType):
+                cells[var_name] = var_value
+            elif isinstance(var_value, types.MethodType):
+                cells[var_name] = var_value
+            elif isinstance(var_value, types.BuiltinFunctionType):
+                cells[var_name] = var_value
+            elif isinstance(var_value, types.BuiltinMethodType):
+                raise TypeNotSupportedError('BuiltinMethodType', var_name, var_value)
+            elif isinstance(var_value, types.WrapperDescriptorType):
+                raise TypeNotSupportedError('WrapperDescriptorType', var_name, var_value)
+            elif isinstance(var_value, types.MethodWrapperType):
+                raise TypeNotSupportedError('MethodWrapperType', var_name, var_value)
+            elif isinstance(var_value, types.MethodDescriptorType):
+                raise TypeNotSupportedError('MethodDescriptorType', var_name, var_value)
+            elif isinstance(var_value, types.ClassMethodDescriptorType):
+                raise TypeNotSupportedError('ClassMethodDescriptorType', var_name, var_value)
+            elif isinstance(var_value, types.ModuleType):
+                cells[var_name] = var_value
+            elif isinstance(var_value, types.TracebackType):
+                raise TypeNotSupportedError('TracebackType', var_name, var_value)
+            elif isinstance(var_value, types.FrameType):
+                raise TypeNotSupportedError('FrameType', var_name, var_value)
+            elif isinstance(var_value, types.GetSetDescriptorType):
+                raise TypeNotSupportedError('GetSetDescriptorType', var_name, var_value)
+            elif isinstance(var_value, types.MemberDescriptorType):
+                raise TypeNotSupportedError('MemberDescriptorType', var_name, var_value)
+            elif isinstance(var_value, types.MappingProxyType):
+                raise TypeNotSupportedError('MappingProxyType', var_name, var_value)
+            else:
+                cells[var_name] = var_value
+
+        return Scope(cells=cells)
+
+    def _get(self, name: str) -> Any:
+        if name in self.cells:
+            return self.cells[name]
+        else:
+            raise NameError(f"{name} not exist in scope.")
+
+    def _get_cells(self) -> Cells:
+        return self.cells
+
+    def _update(self, target_locals: Cells) -> None:
+        for key, value in self.cells.items():
+            target_locals.setdefault(key, value)
+
+    def __repr__(self) -> str:
+        if PRINT_CELL_SIZE:
+            cells = {
+                k: len(pickle.dumps(v, protocol=PICKLE_PROTOCOL))
+                for k, v in self.cells.items()
+            }
+        else:
+            cells = self.cells
+        return f'Scope({cells})'
+
+class Code:
+    def __init__(
+        self, 
+        argcount,
+        cellvars,
+        consts,
+        filename,
+        firstlineno,
+        flags,
+        lnotab,
+        freevars,
+        kwonlyargcount,
+        name,
+        names,
+        nlocals,
+        stacksize,
+        varnames,
+    ) -> None:
+        """Constructor."""
+        self.argcount = argcount
+        self.cellvars = cellvars
+        self.consts = consts
+        self.filename = filename
+        self.firstlineno = firstlineno
+        self.flags = flags
+        self.lnotab = lnotab
+        self.freevars = freevars
+        self.kwonlyargcount = kwonlyargcount
+        self.name = name
+        self.names = names
+        self.nlocals = nlocals
+        self.stacksize = stacksize
+        self.varnames = varnames
+
+    @staticmethod
+    def parse_from(raw_code: CodeType) -> Code:
+        """
+        Parse Python's code into serializable object. 
+        Refer to https://docs.python.org/3/library/inspect.html for code object.
+        """
+        argcount = raw_code.co_argcount
+        # code = raw_code.co_code
+        cellvars = raw_code.co_cellvars
+        consts = raw_code.co_consts
+        filename = raw_code.co_filename
+        firstlineno = raw_code.co_firstlineno
+        flags = raw_code.co_flags
+        lnotab = raw_code.co_lnotab
+        freevars = raw_code.co_freevars
+        # posonlyargcount = raw_code.co_posonlyargcount
+        kwonlyargcount = raw_code.co_kwonlyargcount
+        name = raw_code.co_name
+        # qualname = raw_code.co_qualname
+        names = raw_code.co_names
+        nlocals = raw_code.co_nlocals
+        stacksize = raw_code.co_stacksize
+        varnames = raw_code.co_varnames
+        return Code(
+            argcount=argcount,
+            cellvars=cellvars,
+            consts=consts,
+            filename=filename,
+            firstlineno=firstlineno,
+            flags=flags,
+            lnotab=lnotab,
+            freevars=freevars,
+            kwonlyargcount=kwonlyargcount,
+            name=name,
+            names=names,
+            nlocals=nlocals,
+            stacksize=stacksize,
+            varnames=varnames,
+        )
+
+    def __repr__(self):
+        return 'Code(' \
+            f'argcount= {self.argcount}, ' \
+            f'cellvars= {self.cellvars}, ' \
+            f'consts= {self.consts}, ' \
+            f'filename= {self.filename}, ' \
+            f'firstlineno= {self.firstlineno}, ' \
+            f'flags= {self.flags}, ' \
+            f'lnotab= {self.lnotab}, ' \
+            f'freevars= {self.freevars}, ' \
+            f'kwonlyargcount= {self.kwonlyargcount}, ' \
+            f'name= {self.name}, ' \
+            f'names= {self.names}, ' \
+            f'nlocals= {self.nlocals}, ' \
+            f'stacksize= {self.stacksize}, ' \
+            f'varnames= {self.varnames}' \
+            ')'
+
+
+class Execution:
+    def __init__(self, lasti, lineno) -> None:
+        self.lasti = lasti
+        self.lineno = lineno
+
+    def __repr__(self) -> str:
+        return 'Execution(' \
+            f'lasti= {self.lasti}, ' \
+            f'lineno= {self.lineno}' \
+            f')'
+
+
+class Frame:
+    """
+    A Frame describes the state of a subroutine. It is extracted from Python frame object to be
+    serializable and stable within kishu.
+
+    Frame is decomposed into Scope, Code, and Execution objects.
+    """
+
+    def __init__(self, code: Code, execution: Execution, this_locals: Scope) -> None:
+        """Constructor."""
+        self.code = code
+        self.execution = execution
+        self.locals = this_locals
+
+    @staticmethod
+    def parse_from(raw_frame: FrameType) -> Frame:
+        """
+        Parse Python's frame into serializable object. 
+        Refer to https://docs.python.org/3/library/inspect.html for frame object.
+        """
+        # back = raw_frame.f_back
+        # builtins = raw_frame.f_builtins
+        code = Code.parse_from(raw_frame.f_code)
+        # globals = Scope(raw_frame.f_globals)
+        execution = Execution(raw_frame.f_lasti, raw_frame.f_lineno)
+        this_locals = Scope.parse_from(raw_frame.f_locals)
+        return Frame(
+            code=code,
+            execution=execution,
+            this_locals=this_locals,
+        )
+
+    def get(self, name: str) -> Any:
+        """
+        Get value of a variable inside the frame's scope
+        """
+        return self.locals._get(name)
+
+    def get_cells(self) -> Cells:
+        return self.locals._get_cells()
+
+    def get_execution(self) -> Execution:
+        return self.execution
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """
+        Pickle serialization
+        """
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """
+        Pickle deserialization
+        """
+        self.__dict__.update(state)
+
+    def __repr__(self) -> str:
+        return 'Frame(' \
+            f'execution= {self.execution}' \
+            f')' \
+            f'\n\twith local {self.locals}' \
+            f'\n\twith {self.code}'
+
+class State:
+    """
+    State represents all information sufficient for a recovery.
+
+    Currently, it is only the callstack---a list of frame objects that contain variable scopes,
+    source codes, and execution states.
+    """
+
+    def __init__(self, frames: List[Frame]) -> None:
+        """Constructor."""
+        self.frames = frames
+
+    @staticmethod
+    def parse_from(raw_frames: List[FrameType]) -> State:
+        frames = [Frame.parse_from(raw_frame) for raw_frame in raw_frames]
+        return State(frames=frames)
+
+    def get_frames(self) -> List[Frame]:
+        return self.frames
+
+    def summary(self) -> str:
+        lines = []
+        for frame in self.frames:
+            code = frame.code
+            locals_str = str(frame.locals)
+            exe = frame.execution
+            line = f'{hex(id(frame))}  {code.filename}::{code.name} @ {exe.lasti}, {locals_str}'
+            lines.append(line)
+        return '\n'.join(lines)
+
+    def __repr__(self) -> str:
+        frames_str = '\n'.join([frame.__repr__() for frame in self.frames])
+        frames_str = frames_str.replace('\n', '\n\t')
+        return f'State(\n\t{frames_str}\n)'

--- a/kishu/requirements.txt
+++ b/kishu/requirements.txt
@@ -1,4 +1,8 @@
-dill
-typing
 dataclasses
+dill
+ipylab
+ipynbname
+pytest
+loguru
 shortuuid
+typing

--- a/kishu/setup.py
+++ b/kishu/setup.py
@@ -20,7 +20,7 @@ setup(
     author_email='yongjoo@g.illinois.edu',
     url='https://github.com/illinoisdata/kishu',
     license=license,
-    packages=find_packages(exclude=('tests', 'docs')),
+    packages=find_packages(exclude=('tests', 'docs', 'examples')),
     ext_modules=[Extension("c_idgraph", 
                     sources = ["change/idgraphmodule.c","change/cJSON.c"])]
 )

--- a/kishu/tests/test_capture.py
+++ b/kishu/tests/test_capture.py
@@ -1,0 +1,93 @@
+import pytest
+
+import dill as pickle
+import sys
+import types
+
+from kishu.capture import StandardPythonCapture
+
+
+"""
+TestStandardPythonCapture
+"""
+
+def dummy_variable_depth(depth, truncate_at_depth, capture_depth, truncated_id):
+    if depth == truncate_at_depth:
+        truncated_id = id(sys._getframe())
+
+    if depth > 1:
+        return dummy_variable_depth(depth-1, truncate_at_depth, capture_depth, truncated_id)
+    else:
+        return StandardPythonCapture.capture_state(
+            depth=capture_depth,
+            truncate_at_frame_id=truncated_id,
+        )
+
+def dummy_capture_twice(
+    depth,
+    capture_twice_at_depth,
+    truncated_id,
+):
+    if depth == capture_twice_at_depth:
+        StandardPythonCapture.capture_state(truncate_at_frame_id=truncated_id)
+
+    if depth > 1:
+        return dummy_capture_twice(depth-1, capture_twice_at_depth, truncated_id)
+    else:
+        return StandardPythonCapture.capture_state(truncate_at_frame_id=truncated_id)
+
+
+class TestStandardPythonCapture:
+
+    @pytest.mark.parametrize(
+        "depth,truncate_at_depth,capture_depth",
+        [
+            (1, 2, 0),
+            (1, 1, 0),
+            (1, 2, 1),
+            (1, 2, 2),
+            (5, 1, 1),
+            (5, 2, 2),
+            (5, 1, 3),
+        ],
+    )
+    def test_correct_capture_amount(self, depth, truncate_at_depth, capture_depth):
+        truncated_base_id = id(sys._getframe())  # Stop here before backtracking into pytest
+        state, same_frames = dummy_variable_depth(
+            depth,
+            truncate_at_depth,
+            capture_depth,
+            truncated_base_id,
+        )
+        starting_depth = min(depth, truncate_at_depth - 1)
+        assert len(state.get_frames()) == len(same_frames)
+        assert len(state.get_frames()) == max(starting_depth - capture_depth, 0)
+        assert not any(same_frames)
+
+
+    @pytest.mark.parametrize(
+        "depth,capture_twice_at_depth",
+        [
+            (1, 2),
+            (1, 1),
+            (3, 1),
+            (3, 2),
+            (3, 3),
+            (6, 1),
+            (6, 2),
+            (6, 3),
+            (6, 4),
+            (6, 5),
+            (6, 6),
+        ],
+    )
+    def test_same_frames(self, depth, capture_twice_at_depth):
+        truncated_base_id = id(sys._getframe())  # Stop here before backtracking into pytest
+        state, same_frames = dummy_capture_twice(
+            depth,
+            capture_twice_at_depth,
+            truncated_base_id,
+        )
+        assert len(state.get_frames()) == len(same_frames)
+        assert len(state.get_frames()) == depth
+        assert sum(same_frames) == depth - (capture_twice_at_depth - 1)

--- a/kishu/tests/test_delta.py
+++ b/kishu/tests/test_delta.py
@@ -1,0 +1,64 @@
+import pytest
+
+import dill as pickle
+import sys
+import types
+
+from kishu.state import State
+from kishu.delta import StateDelta
+
+
+"""
+TestDelta
+"""
+
+def dummy_parameterized(a, make_b):
+    if make_b:
+        b = "added"
+    c = [a]
+    return sys._getframe()
+
+
+class TestDelta:
+    """Tests parsing from frame object to Frame."""
+
+    @pytest.mark.parametrize(
+        "from_a,from_make_b,to_a,to_make_b,same_frame,added_names,deleted_names",
+        [
+            # Same frames
+            ("1", True, "1", True, True, [], []),
+            ("1", True, "999", True, True, ["a"], []),  # No "c" since "a" is shared.
+            ("1", False, "1", True, True, ["make_b", "b"], []),
+            ("1", True, "1", False, True, ["make_b"], ["b"]),
+
+            # Different frames
+            ("1", True, "1", True, False, ["a", "make_b", "b", "c"], []),
+            ("1", True, "999", True, False, ["a", "make_b", "b", "c"], []),
+            ("1", False, "1", True, False, ["a", "make_b", "b", "c"], []),
+            ("1", True, "1", False, False, ["a", "make_b", "c"], ["b"]),
+        ],
+    )
+    def test_single_frame(
+        self,
+        from_a,
+        from_make_b,
+        to_a,
+        to_make_b,
+        same_frame,
+        added_names,
+        deleted_names,
+    ):
+        from_state = State.parse_from([dummy_parameterized(a=from_a, make_b=from_make_b)])
+        to_state = State.parse_from([dummy_parameterized(a=to_a, make_b=to_make_b)])
+        same_frames = [same_frame]
+        assert len(from_state.get_frames()) == 1
+        assert len(to_state.get_frames()) == 1
+
+        delta = StateDelta.delta(from_state, to_state, same_frames)
+        scope_deltas = delta.get_scope_deltas()
+        assert len(scope_deltas) == 1
+
+        scope_delta = scope_deltas[0]
+        assert set(scope_delta.get_added().keys()) == set(added_names)
+        assert scope_delta.get_deleted() == set(deleted_names)
+        assert scope_delta.get_execution() is to_state.get_frames()[0].get_execution()

--- a/kishu/tests/test_state.py
+++ b/kishu/tests/test_state.py
@@ -1,0 +1,161 @@
+import pytest
+
+import dill as pickle
+import sys
+import types
+
+from kishu.exceptions import TypeNotSupportedError
+from kishu.state import ContinuousPickler, Scope, State
+
+
+"""
+TestFrameParsing
+"""
+
+def dummy_function_frame(i=9):
+    a = 1
+    b = "2"
+    c = [3]
+    d = {4}
+    e = {5: 5}
+    def f():
+        return 6
+    g = a + f()
+    h = type(8)
+    return sys._getframe()
+
+
+def dummy_deep_function_frame(depth=3):
+    if depth > 1:
+        return dummy_deep_function_frame(depth=depth-1)
+    x = 1
+    y = "2"
+    return sys._getframe()
+
+
+def unserializable_generator():
+    for idx in range(10):
+        yield idx
+
+
+class TestFrameParsing:
+    """Tests parsing from frame object to Frame."""
+
+    def test_function_frame(self):
+        state = State.parse_from([dummy_function_frame()])
+        assert len(state.get_frames()) == 1
+        frame = state.get_frames()[0]
+
+        # Test get
+        assert frame.get("a") == 1
+        assert frame.get("b") == "2"
+        assert frame.get("c") == [3]
+        assert frame.get("d") == {4}
+        assert frame.get("e") == {5: 5}
+        assert isinstance(frame.get("f"), types.FunctionType) and frame.get("f")() == 6
+        assert frame.get("g") == 7
+        assert frame.get("h") == int
+        assert frame.get("i") == 9
+
+        # Test get_cells
+        cells = frame.get_cells()
+        assert len(cells) == 9
+        assert cells["a"] == 1
+        assert cells["b"] == "2"
+        assert cells["c"] == [3]
+        assert cells["d"] == {4}
+        assert cells["e"] == {5: 5}
+        assert isinstance(cells["f"], types.FunctionType) and cells["f"]() == 6
+        assert cells["g"] == 7
+        assert cells["h"] == int
+        assert cells["i"] == 9
+
+        # Test get_execution
+        execution = frame.get_execution()
+        assert execution.lasti > 0  # Could be flaky to specify this.
+        assert execution.lineno > 0  # Could be flaky to specify this.
+
+        # Test serializable
+        serialized_frame = pickle.dumps(frame)
+        assert len(serialized_frame) > 0
+
+
+    def test_deep_function_frame_frame(self):
+        state = State.parse_from([dummy_deep_function_frame()])
+        assert len(state.get_frames()) == 1
+        frame = state.get_frames()[0]
+
+        # Test get
+        assert frame.get("x") == 1
+        assert frame.get("y") == "2"
+        assert frame.get("depth") == 1
+
+        # Test get_cells
+        cells = frame.get_cells()
+        assert len(cells) == 3
+        assert cells["x"] == 1
+        assert cells["y"] == "2"
+        assert cells["depth"] == 1
+
+        # Test get_execution
+        execution = frame.get_execution()
+        assert execution.lasti > 0  # Could be flaky to specify this.
+        assert execution.lineno > 0  # Could be flaky to specify this.
+
+        # Test serializable
+        serialized_frame = pickle.dumps(frame)
+        assert len(serialized_frame) > 0
+
+
+    def test_many_frames(self):
+        state = State.parse_from([dummy_function_frame(), dummy_function_frame()])
+        assert len(state.get_frames()) == 2
+
+
+    @pytest.mark.parametrize(
+        "not_supported_obj",
+        [
+            unserializable_generator(),  # GeneratorType, TODO: enable this
+            sys._getframe(),  # FrameType
+        ]
+    )
+    def test_fail_type_not_supported(self, not_supported_obj):
+        with pytest.raises(TypeNotSupportedError):
+            Scope.parse_from({"not_supported_obj": not_supported_obj})
+
+
+"""
+TestContinuousPickling
+"""
+
+class TestContinuousPickling:
+
+    def test_smaller_size_when_shared(self):
+        a = [idx for idx in range(1000)]
+        b = [a]
+
+        pickler = ContinuousPickler()
+        shared_size = len(pickler.dumps(a)) + len(pickler.dumps(b))
+
+        pickler = ContinuousPickler()
+        a_size = len(pickler.dumps(a))
+        pickler = ContinuousPickler()
+        b_size = len(pickler.dumps(b))
+        separated_size = a_size + b_size
+
+        assert shared_size < separated_size
+
+    def test_not_smaller_size_when_not_shared(self):
+        a = [idx for idx in range(1000)]
+        b = [idx for idx in range(1000)]
+
+        pickler = ContinuousPickler()
+        shared_size = len(pickler.dumps(a)) + len(pickler.dumps(b))
+
+        pickler = ContinuousPickler()
+        a_size = len(pickler.dumps(a))
+        pickler = ContinuousPickler()
+        b_size = len(pickler.dumps(b))
+        separated_size = a_size + b_size
+
+        assert shared_size >= separated_size


### PR DESCRIPTION
Changes:
- Migrate source code for DEEM'23 submission
- Improve module interfaces
- Add type hints

Structure:
- `exceptions.py`: central collection of exceptions
- `state.py`: definition of recoverable/sufficient state
- `delta.py`: logic to find delta based on state
- `capture.py`: standard Python capture logics + periodic watchdog
- `examples/target_longrunning.py`: simple target program example to test `capture.py` on

Manual test:
```
python kishu/capture.py examples/target_longrunning.py
python kishu/capture.py --verbosity=2 examples/target_longrunning.py
python kishu/capture.py --cpu-sampling-rate=10.0 examples/target_longrunning.py
```