### PR TITLE
Read commit summary through CLI log, log_all, status

### DIFF
--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+import enum
+import json
+import simple_parsing
+import dataclasses
+from typing import Any, Callable, Dict, List, Optional
+
+from kishu.commands import KishuCommand
+
+
+"""
+Printing dataclasses
+"""
+
+
+class DataclassJSONEncoder(json.JSONEncoder):
+
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        try:
+            return super().default(o)
+        except TypeError:
+            return o.__repr__()
+
+
+def print_dataclass(data: Any):
+    print(json.dumps(data, cls=DataclassJSONEncoder, indent=2))
+
+
+"""
+Command Line Interface.
+"""
+
+
+class Command(enum.Enum):
+    help = "help"
+    log = "log"
+    log_all = "log_all"
+    status = "status"
+
+
+@dataclasses.dataclass
+class KishuCLIArguments:
+    """Interact with Kishu-powered programs."""
+    command: Command = Command.help  # Kishu command.
+    notebook_id: Optional[str] = None  # Notebook ID to interact with.
+    commit_id: Optional[str] = None  # Commit ID to apply command on.
+
+    @staticmethod
+    def from_argv(argv: List[str]) -> KishuCLIArguments:
+        if (
+            len(argv) >= 1
+            and "--command" not in argv
+            and "--help" not in argv
+            and "-h" not in argv
+        ):
+            # Takes first argument as the command.
+            argv = ["--command"] + argv
+        return simple_parsing.parse(KishuCLIArguments, args=argv)
+
+    @staticmethod
+    def print_help() -> None:
+        simple_parsing.parse(KishuCLIArguments, args="--help")
+
+
+class KishuCLI:
+
+    def __init__(self) -> None:
+        # Per-session state goes here.
+        self._commands: Dict[Command, Callable[[KishuCLIArguments], None]] = {
+            Command.help: self.help,
+            Command.log: self.log,
+            Command.log_all: self.log_all,
+            Command.status: self.status,
+        }
+
+    def exec(self, args):
+        func = self.dispatch(args.command)
+        func(args)
+
+    def dispatch(self, command) -> Callable[[KishuCLIArguments], None]:
+        return self._commands[command]
+
+    def help(self, args):
+        print(f"commands: {' | '.join([cmd.value for cmd in Command])}")
+        KishuCLIArguments.print_help()
+
+    def log(self, args):
+        assert args.notebook_id is not None, "log requires notebook_id."
+        assert args.commit_id is not None, "log requires commit_id."
+        print_dataclass(KishuCommand.log(args.notebook_id, args.commit_id))
+
+    def log_all(self, args):
+        assert args.notebook_id is not None, "log_all requires notebook_id."
+        print_dataclass(KishuCommand.log_all(args.notebook_id))
+
+    def status(self, args):
+        assert args.notebook_id is not None, "status requires notebook_id."
+        assert args.commit_id is not None, "status requires commit_id."
+        print_dataclass(KishuCommand.status(args.notebook_id, args.commit_id))
+
+
+if __name__ == "__main__":
+    # Parse argugments from command line.
+    import sys
+    args = KishuCLIArguments.from_argv(sys.argv[1:])
+
+    # Execute
+    cli = KishuCLI()
+    cli.exec(args)

--- a/kishu/kishu/commands.py
+++ b/kishu/kishu/commands.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List, Optional, cast
+
+from kishu.resources import KishuResource
+from kishu.commit_graph import CommitInfo, KishuCommitGraph
+from kishu.plan import UnitExecution
+from kishu.jupyterint2 import CellExecInfo
+
+
+@dataclass
+class CommitSummary:
+    commit_id: str
+    parent_id: str
+    code_block: Optional[str]
+    runtime_ms: Optional[int]
+
+
+@dataclass
+class LogResult:
+    commit_graph: List[CommitSummary]
+
+
+@dataclass
+class LogAllResult:
+    commit_graph: List[CommitSummary]
+
+
+@dataclass
+class StatusResult:
+    commit_info: CommitInfo
+    cell_exec_info: CellExecInfo
+
+
+class KishuCommand:
+
+    @staticmethod
+    def log(notebook_id: str, commit_id: str) -> LogResult:
+        store = KishuCommitGraph.new_on_file(KishuResource.commit_graph_directory(notebook_id))
+        graph = store.list_history(commit_id)
+        return LogResult(KishuCommand._augment_from_checkpoint(notebook_id, graph))
+
+    @staticmethod
+    def log_all(notebook_id: str) -> LogAllResult:
+        store = KishuCommitGraph.new_on_file(KishuResource.commit_graph_directory(notebook_id))
+        graph = store.list_all_history()
+        return LogAllResult(KishuCommand._augment_from_checkpoint(notebook_id, graph))
+
+    @staticmethod
+    def status(notebook_id: str, commit_id: str) -> StatusResult:
+        commit_info = next(
+            KishuCommitGraph.new_on_file(KishuResource.commit_graph_directory(notebook_id))
+                            .iter_history(commit_id)
+        )
+
+        # TODO: Pull CellExecInfo logic out of jupyterint2 to avoid this cast.
+        cell_exec_info: CellExecInfo = cast(
+            CellExecInfo,
+            UnitExecution.get_from_db(
+                KishuResource.checkpoint_path(notebook_id),
+                commit_id,
+            )
+        )
+        return StatusResult(
+            commit_info=commit_info,
+            cell_exec_info=cell_exec_info
+        )
+
+    @staticmethod
+    def _augment_from_checkpoint(notebook_id: str, graph: List[CommitInfo]) -> List[CommitSummary]:
+        exec_infos = UnitExecution.get_commits(
+            KishuResource.checkpoint_path(notebook_id),
+            [node.commit_id for node in graph]
+        )
+        return KishuCommand._join(graph, exec_infos)
+
+    @staticmethod
+    def _join(graph: List[CommitInfo], exec_infos: Dict[str, UnitExecution]) -> List[CommitSummary]:
+        summaries = []
+        for node in graph:
+            exec_info = exec_infos.get(node.commit_id, UnitExecution())
+            summaries.append(CommitSummary(
+                commit_id=node.commit_id,
+                parent_id=node.parent_id,
+                code_block=exec_info.code_block,
+                runtime_ms=exec_info.runtime_ms,
+            ))
+        return summaries

--- a/kishu/kishu/resources.py
+++ b/kishu/kishu/resources.py
@@ -1,0 +1,45 @@
+import os
+import pathlib
+
+
+class KishuResource:
+    ROOT = pathlib.Path.home()
+
+    @staticmethod
+    def kishu_directory() -> str:
+        """
+        Gets a directory for storing kishu states. Creates if none exists.
+        """
+        return KishuResource._create_dir(os.path.join(KishuResource.ROOT, ".kishu"))
+
+    @staticmethod
+    def notebook_directory(notebook_id: str) -> str:
+        """
+        Creates a directory kishu will use for checkpointing a notebook. Creates if none exists.
+        """
+        return KishuResource._create_dir(os.path.join(KishuResource.kishu_directory(), notebook_id))
+
+    @staticmethod
+    def checkpoint_path(notebook_id: str) -> str:
+        return os.path.join(KishuResource.notebook_directory(notebook_id), "ckpt.sqlite")
+
+    @staticmethod
+    def commit_graph_directory(notebook_id: str) -> str:
+        return KishuResource._create_dir(os.path.join(
+            KishuResource.notebook_directory(notebook_id),
+            "commit_graph")
+        )
+
+    @staticmethod
+    def _create_dir(dir: str) -> str:
+        """
+        Creates a new directory if not exists.
+
+        @param dir  A directory to create.
+        @return  Echos the newly created directory.
+        """
+        if os.path.isfile(dir):
+            raise ValueError("The passed directory name exists as s file.")
+        if not os.path.exists(dir):
+            os.mkdir(dir)
+        return dir

--- a/kishu/requirements.txt
+++ b/kishu/requirements.txt
@@ -5,4 +5,5 @@ ipynbname
 pytest
 loguru
 shortuuid
+simple_parsing
 typing

--- a/kishu/tests/test_cli.py
+++ b/kishu/tests/test_cli.py
@@ -1,0 +1,40 @@
+import pytest
+
+from kishu.cli import Command, KishuCLIArguments
+
+
+class TestKishuCLIArguments:
+
+    def test_no_arg(self):
+        args = KishuCLIArguments.from_argv([])
+        assert args.command == Command.help
+        assert args.notebook_id is None
+        assert args.commit_id is None
+
+    def test_help(self):
+        with pytest.raises(SystemExit):
+            KishuCLIArguments.from_argv(["--help"])
+
+        with pytest.raises(SystemExit):
+            KishuCLIArguments.from_argv(["random", "args?", "--help", "--commit_id"])
+
+        with pytest.raises(SystemExit):
+            KishuCLIArguments.from_argv(["random", "args?", "-h", "--commit_id"])
+
+    def test_log(self):
+        args = KishuCLIArguments.from_argv(['log', '--notebook_id', '123', '--commit_id', '4567'])
+        assert args.command == Command.log
+        assert args.notebook_id == '123'
+        assert args.commit_id == '4567'
+
+    def test_log_all(self):
+        args = KishuCLIArguments.from_argv(['log_all', '--notebook_id', '123', '--commit_id', '4567'])
+        assert args.command == Command.log_all
+        assert args.notebook_id == '123'
+        assert args.commit_id == '4567'
+
+    def test_status(self):
+        args = KishuCLIArguments.from_argv(['status', '--notebook_id', '123', '--commit_id', '4567'])
+        assert args.command == Command.status
+        assert args.notebook_id == '123'
+        assert args.commit_id == '4567'

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -1,0 +1,133 @@
+import pytest
+import dataclasses
+from typing import Generator, List, Optional, Type
+
+from kishu.resources import KishuResource
+from kishu.jupyterint2 import CellExecInfo, KishuForJupyter
+from kishu.commit_graph import CommitInfo
+from kishu.commands import CommitSummary, KishuCommand
+
+
+@pytest.fixture()
+def kishu_resource(tmp_path) -> Generator[Type[KishuResource], None, None]:
+    original_root = KishuResource.ROOT
+    KishuResource.ROOT = tmp_path
+    yield KishuResource
+    KishuResource.ROOT = original_root
+
+
+@pytest.fixture()
+def notebook_id() -> Generator[str, None, None]:
+    yield "notebook_123"
+
+
+@pytest.fixture()
+def kishu_jupyter(kishu_resource, notebook_id) -> Generator[KishuForJupyter, None, None]:
+    kishu_jupyter = KishuForJupyter(notebook_id=notebook_id)
+    yield kishu_jupyter
+
+
+@pytest.fixture()
+def basic_execution_ids(kishu_jupyter) -> Generator[List[str], None, None]:
+    execution_count = 1
+    info = JupyterInfoMock(raw_cell="x = 1")
+    kishu_jupyter.pre_run_cell(info)
+    kishu_jupyter.post_run_cell(JupyterResultMock(info=info, execution_count=execution_count))
+    execution_count = 2
+    info = JupyterInfoMock(raw_cell="y = 2")
+    kishu_jupyter.pre_run_cell(info)
+    kishu_jupyter.post_run_cell(JupyterResultMock(info=info, execution_count=execution_count))
+    execution_count = 3
+    info = JupyterInfoMock(raw_cell="y = x + 1")
+    kishu_jupyter.pre_run_cell(info)
+    kishu_jupyter.post_run_cell(JupyterResultMock(info=info, execution_count=execution_count))
+
+    yield ["1", "2", "3"]  # List of commit IDs
+
+
+@dataclasses.dataclass
+class JupyterInfoMock:
+    raw_cell: Optional[str] = None
+
+
+@dataclasses.dataclass
+class JupyterResultMock:
+    info: JupyterInfoMock = JupyterInfoMock()
+    execution_count: Optional[int] = None
+    error_before_exec: Optional[str] = None
+    error_in_exec: Optional[str] = None
+    result: Optional[str] = None
+
+
+class TestKishuCommand:
+
+    def test_log(self, notebook_id, basic_execution_ids):
+        log_result = KishuCommand.log(notebook_id, basic_execution_ids[-1])
+        assert len(log_result.commit_graph) == 3
+        assert log_result.commit_graph[0] == CommitSummary(
+            commit_id="3",
+            parent_id="2",
+            code_block="y = x + 1",
+            runtime_ms=log_result.commit_graph[0].runtime_ms,  # Not tested
+        )
+        assert log_result.commit_graph[1] == CommitSummary(
+            commit_id="2",
+            parent_id="1",
+            code_block="y = 2",
+            runtime_ms=log_result.commit_graph[1].runtime_ms,  # Not tested
+        )
+        assert log_result.commit_graph[2] == CommitSummary(
+            commit_id="1",
+            parent_id="",
+            code_block="x = 1",
+            runtime_ms=log_result.commit_graph[2].runtime_ms,  # Not tested
+        )
+
+        log_result = KishuCommand.log(notebook_id, basic_execution_ids[0])
+        assert len(log_result.commit_graph) == 1
+        assert log_result.commit_graph[0] == CommitSummary(
+            commit_id="1",
+            parent_id="",
+            code_block="x = 1",
+            runtime_ms=log_result.commit_graph[0].runtime_ms,  # Not tested
+        )
+
+    def test_log_all(self, notebook_id, basic_execution_ids):
+        log_all_result = KishuCommand.log_all(notebook_id)
+        assert len(log_all_result.commit_graph) == 3
+        assert log_all_result.commit_graph[0] == CommitSummary(
+            commit_id="1",
+            parent_id="",
+            code_block="x = 1",
+            runtime_ms=log_all_result.commit_graph[0].runtime_ms,  # Not tested
+        )
+        assert log_all_result.commit_graph[1] == CommitSummary(
+            commit_id="2",
+            parent_id="1",
+            code_block="y = 2",
+            runtime_ms=log_all_result.commit_graph[1].runtime_ms,  # Not tested
+        )
+        assert log_all_result.commit_graph[2] == CommitSummary(
+            commit_id="3",
+            parent_id="2",
+            code_block="y = x + 1",
+            runtime_ms=log_all_result.commit_graph[2].runtime_ms,  # Not tested
+        )
+
+    def test_status(self, notebook_id, basic_execution_ids):
+        status_result = KishuCommand.status(notebook_id, basic_execution_ids[-1])
+        assert status_result.commit_info == CommitInfo(
+            commit_id="3",
+            parent_id="2",
+        )
+        assert status_result.cell_exec_info == CellExecInfo(
+            exec_id="3",
+            execution_count=3,
+            code_block="y = x + 1",
+            checkpoint_vars=[],
+            start_time_ms=status_result.cell_exec_info.start_time_ms,  # Not tested
+            end_time_ms=status_result.cell_exec_info.end_time_ms,  # Not tested
+            checkpoint_runtime_ms=status_result.cell_exec_info.checkpoint_runtime_ms,  # Not tested
+            runtime_ms=status_result.cell_exec_info.runtime_ms,  # Not tested
+            _restore_plan=status_result.cell_exec_info._restore_plan,  # Not tested
+        )

--- a/kishu/tests/test_commit_graph.py
+++ b/kishu/tests/test_commit_graph.py
@@ -25,7 +25,7 @@ class TestCommitNode:
         Tests all methods in CommitNode.
         """
         info = CommitInfo(commit_id, parent_id)
-        node = CommitNode(commit_id, parent_id, info)
+        node = CommitNode(info)
         assert node.commit_id() == commit_id
         assert node.parent_id() == parent_id
         assert node.info() == info
@@ -54,8 +54,8 @@ class TestCommitNode:
 
     def test_too_large(self):
         large_id = "large_commit_" * NODE_SIZE
-        node = CommitNode(large_id, "", CommitInfo(large_id, ""))
-        with pytest.raises(ValueError, match=r"CommitNode is too large (.* > .*)"):
+        node = CommitNode(CommitInfo(large_id, ""))
+        with pytest.raises(ValueError, match=r"CommitNode .* is too large (.* > .*)"):
             node.serialize()  # Expect fail
 
 


### PR DESCRIPTION
- Move path resolution to a common location (resource.py)
- Query multiple commit IDs in one batch
- Build read-only commands: log (history up to commit), log_all (every commit), and status (single commit in detail)
- Setup CLI
- Fix all flake/mypy issues in touched files

Layers from user to internal
1. cli.py
2. commands.py (this will be reused with the backend server)
3. Internal readers (commit_graph.py, plan.py, jupyterint2.py)