### PR TITLE
Read commit summary and support APIs for FE through Flask backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,31 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+py38/
+.kishu
+
+
+### kishu/timetravel_fe
+
+# dependencies
+kishu/timetravel_fe/node_modules
+kishu/timetravel_fe/.pnp
+kishu/timetravel_fe/.pnp.js
+
+# testing
+kishu/timetravel_fe/coverage
+
+# production
+kishu/timetravel_fe/build
+
+# misc
+kishu/timetravel_fe/.DS_Store
+kishu/timetravel_fe/.env.local
+kishu/timetravel_fe/.env.development.local
+kishu/timetravel_fe/.env.test.local
+kishu/timetravel_fe/.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/kishu/README.md
+++ b/kishu/README.md
@@ -44,7 +44,12 @@ Restore a state.
 _kishu.checkout(checkpoint_file, commit_id)
 ```
 
+## Checkpoint Backend
 
+Deploy a restful server.
+```
+flask --app kishu/backend run
+```
 
 # Deployment
 

--- a/kishu/kishu/backend.py
+++ b/kishu/kishu/backend.py
@@ -1,0 +1,44 @@
+from flask import Flask
+
+import json
+
+from kishu.serialization import into_json
+from kishu.commands import KishuCommand
+
+
+app = Flask("kishu_server")
+
+
+@app.get("/health")
+def health():
+    return json.dumps({"status": "ok"})
+
+
+@app.get("/log/<notebook_id>/<commit_id>")
+def log(notebook_id: str, commit_id: str):
+    log_result = KishuCommand.log(notebook_id, commit_id)
+    return into_json(log_result)
+
+
+@app.get("/log_all/<notebook_id>")
+def log_all(notebook_id: str):
+    log_all_result = KishuCommand.log_all(notebook_id)
+    return into_json(log_all_result)
+
+
+@app.get("/status/<notebook_id>/<commit_id>")
+def status(notebook_id: str, commit_id: str):
+    status_result = KishuCommand.status(notebook_id, commit_id)
+    return into_json(status_result)
+
+
+@app.get("/fe/initialize/<notebook_id>")
+def fe_initialize(notebook_id: str):
+    fe_initialize_result = KishuCommand.fe_initialize(notebook_id)
+    return into_json(fe_initialize_result)
+
+
+@app.get("/fe/history/<notebook_id>/<commit_id>")
+def fe_history(notebook_id: str, commit_id: str):
+    fe_history_result = KishuCommand.fe_history(notebook_id, commit_id)
+    return into_json(fe_history_result)

--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -1,31 +1,11 @@
 from __future__ import annotations
-import enum
-import json
-import simple_parsing
 import dataclasses
-from typing import Any, Callable, Dict, List, Optional
+import enum
+import simple_parsing
+from typing import Callable, Dict, List, Optional
 
+from kishu.serialization import into_json
 from kishu.commands import KishuCommand
-
-
-"""
-Printing dataclasses
-"""
-
-
-class DataclassJSONEncoder(json.JSONEncoder):
-
-    def default(self, o):
-        if dataclasses.is_dataclass(o):
-            return dataclasses.asdict(o)
-        try:
-            return super().default(o)
-        except TypeError:
-            return o.__repr__()
-
-
-def print_dataclass(data: Any):
-    print(json.dumps(data, cls=DataclassJSONEncoder, indent=2))
 
 
 """
@@ -89,16 +69,16 @@ class KishuCLI:
     def log(self, args):
         assert args.notebook_id is not None, "log requires notebook_id."
         assert args.commit_id is not None, "log requires commit_id."
-        print_dataclass(KishuCommand.log(args.notebook_id, args.commit_id))
+        print(into_json(KishuCommand.log(args.notebook_id, args.commit_id)))
 
     def log_all(self, args):
         assert args.notebook_id is not None, "log_all requires notebook_id."
-        print_dataclass(KishuCommand.log_all(args.notebook_id))
+        print(into_json(KishuCommand.log_all(args.notebook_id)))
 
     def status(self, args):
         assert args.notebook_id is not None, "status requires notebook_id."
         assert args.commit_id is not None, "status requires commit_id."
-        print_dataclass(KishuCommand.status(args.notebook_id, args.commit_id))
+        print(into_json(KishuCommand.status(args.notebook_id, args.commit_id)))
 
 
 if __name__ == "__main__":

--- a/kishu/kishu/serialization.py
+++ b/kishu/kishu/serialization.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import dataclasses
+import json
+
+
+"""
+Printing dataclasses
+"""
+
+
+class DataclassJSONEncoder(json.JSONEncoder):
+
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        try:
+            return super().default(o)
+        except TypeError:
+            return o.__repr__()
+
+
+def into_json(data):
+    return json.dumps(data, cls=DataclassJSONEncoder, indent=2)

--- a/kishu/requirements.txt
+++ b/kishu/requirements.txt
@@ -7,3 +7,4 @@ loguru
 shortuuid
 simple_parsing
 typing
+flask

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -5,7 +5,7 @@ from typing import Generator, List, Optional, Type
 from kishu.resources import KishuResource
 from kishu.jupyterint2 import CellExecInfo, KishuForJupyter
 from kishu.commit_graph import CommitInfo
-from kishu.commands import CommitSummary, KishuCommand
+from kishu.commands import CommitSummary, KishuCommand, SelectedHistory
 
 
 @pytest.fixture()
@@ -130,4 +130,17 @@ class TestKishuCommand:
             checkpoint_runtime_ms=status_result.cell_exec_info.checkpoint_runtime_ms,  # Not tested
             runtime_ms=status_result.cell_exec_info.runtime_ms,  # Not tested
             _restore_plan=status_result.cell_exec_info._restore_plan,  # Not tested
+        )
+
+    def test_fe_initialize(self, notebook_id, basic_execution_ids):
+        fe_initialize_result = KishuCommand.fe_initialize(notebook_id)
+        assert len(fe_initialize_result.histories) == 3
+
+    def test_fe_history(self, notebook_id, basic_execution_ids):
+        fe_history_result = KishuCommand.fe_history(notebook_id, basic_execution_ids[-1])
+        assert fe_history_result == SelectedHistory(
+            oid="3",
+            timestamp=fe_history_result.timestamp,  # Not tested
+            exec_cell="y = x + 1",
+            variables=[],
         )


### PR DESCRIPTION
- Wrap the same commands (as CLI) in the Flask backend
- Implement APIs for frontend per Hanxi's design
  - Lacking: branch, current notebook cells

Tested in unit test and manual curl-ing

Deploy via `flask --app kishu/backend run` 