### PR TITLE
Checkout a commit through Jupyter client

### DIFF
--- a/kishu/README.md
+++ b/kishu/README.md
@@ -41,7 +41,7 @@ _kishu.checkpoint_file()
 
 Restore a state.
 ```
-_kishu.checkout(checkpoint_file, commit_id)
+_kishu.checkout(commit_id)
 ```
 
 ## Checkpoint Backend

--- a/kishu/kishu/backend.py
+++ b/kishu/kishu/backend.py
@@ -32,6 +32,12 @@ def status(notebook_id: str, commit_id: str):
     return into_json(status_result)
 
 
+@app.get("/checkout/<notebook_id>/<commit_id>")
+def checkout(notebook_id: str, commit_id: str):
+    checkout_result = KishuCommand.checkout(notebook_id, commit_id)
+    return into_json(checkout_result)
+
+
 @app.get("/fe/initialize/<notebook_id>")
 def fe_initialize(notebook_id: str):
     fe_initialize_result = KishuCommand.fe_initialize(notebook_id)

--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -19,6 +19,8 @@ class Command(enum.Enum):
     log_all = "log_all"
     status = "status"
 
+    checkout = "checkout"
+
 
 @dataclasses.dataclass
 class KishuCLIArguments:
@@ -53,6 +55,7 @@ class KishuCLI:
             Command.log: self.log,
             Command.log_all: self.log_all,
             Command.status: self.status,
+            Command.checkout: self.checkout,
         }
 
     def exec(self, args):
@@ -79,6 +82,11 @@ class KishuCLI:
         assert args.notebook_id is not None, "status requires notebook_id."
         assert args.commit_id is not None, "status requires commit_id."
         print(into_json(KishuCommand.status(args.notebook_id, args.commit_id)))
+
+    def checkout(self, args):
+        assert args.notebook_id is not None, "checkout requires notebook_id."
+        assert args.commit_id is not None, "checkout requires commit_id."
+        print(into_json(KishuCommand.checkout(args.notebook_id, args.commit_id)))
 
 
 if __name__ == "__main__":

--- a/kishu/kishu/resources.py
+++ b/kishu/kishu/resources.py
@@ -31,6 +31,10 @@ class KishuResource:
         )
 
     @staticmethod
+    def connection_path(notebook_id: str) -> str:
+        return os.path.join(KishuResource.notebook_directory(notebook_id), "connection.json")
+
+    @staticmethod
     def _create_dir(dir: str) -> str:
         """
         Creates a new directory if not exists.

--- a/kishu/requirements.txt
+++ b/kishu/requirements.txt
@@ -8,3 +8,4 @@ shortuuid
 simple_parsing
 typing
 flask
+dataclasses-json

--- a/kishu/tests/test_jupyter_checkout.ipynb
+++ b/kishu/tests/test_jupyter_checkout.ipynb
@@ -176,7 +176,7 @@
     }
    ],
    "source": [
-    "_kishu.checkout(_, 2)"
+    "_kishu.checkout(2)"
    ]
   },
   {


### PR DESCRIPTION
Checkout Flow
- Record kernel ID when attaching Kishu instrument (`load_kishu()`)
- To checkout
  - Read connection info (kernel ID)
  - Establish a connection through Jupyter client
  - Submit a Kishu checkout invocation
  - On the Jupyter kernel, Kishu checkout read checkpoint and load variables into user namespace

Tested: CLI + Backend
