### PR TITLE
Allow branch naming and step HEAD branch forward at commit time

### DIFF
--- a/kishu/kishu/backend.py
+++ b/kishu/kishu/backend.py
@@ -38,6 +38,12 @@ def checkout(notebook_id: str, commit_id: str):
     return into_json(checkout_result)
 
 
+@app.get("/branch/<notebook_id>/<branch_name>")
+def branch(notebook_id: str, branch_name: str):
+    branch_result = KishuCommand.branch(notebook_id, branch_name, None)
+    return into_json(branch_result)
+
+
 @app.get("/fe/initialize/<notebook_id>")
 def fe_initialize(notebook_id: str):
     fe_initialize_result = KishuCommand.fe_initialize(notebook_id)

--- a/kishu/kishu/branch.py
+++ b/kishu/kishu/branch.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+import json
+import sqlite3
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+from typing import List, Optional
+
+from kishu.checkpoint_io import BRANCH_TABLE
+from kishu.resources import KishuResource
+
+
+@dataclass_json
+@dataclass
+class HeadBranch:
+    branch_name: Optional[str]
+    commit_id: Optional[str]
+
+
+@dataclass
+class BranchRow:
+    branch_name: str
+    commit_id: str
+
+
+class KishuBranch:
+
+    @staticmethod
+    def get_head(notebook_id: str) -> Optional[HeadBranch]:
+        try:
+            with open(KishuResource.head_path(notebook_id), "r") as f:
+                json_str = f.read()
+                return HeadBranch.from_json(json_str)  # type: ignore
+        except (FileNotFoundError, json.decoder.JSONDecodeError):
+            return None
+
+    @staticmethod
+    def update_head(
+        notebook_id: str,
+        branch_name: Optional[str] = None,
+        commit_id: Optional[str] = None,
+        is_detach: bool = False
+    ) -> HeadBranch:
+        head = KishuBranch.get_head(notebook_id)
+        if head is None:
+            head = HeadBranch(branch_name=None, commit_id=None)
+        if branch_name is not None or is_detach:
+            head.branch_name = branch_name
+        if commit_id is not None:
+            head.commit_id = commit_id
+        with open(KishuResource.head_path(notebook_id), 'w') as f:
+            f.write(head.to_json())  # type: ignore
+        return head
+
+    @staticmethod
+    def upsert_branch(notebook_id: str, branch: str, commit_id: str) -> None:
+        dbfile = KishuResource.checkpoint_path(notebook_id)
+        con = sqlite3.connect(dbfile)
+        cur = con.cursor()
+        query = f"insert or replace into {BRANCH_TABLE} values (?, ?)"
+        cur.execute(query, (branch, commit_id))
+        con.commit()
+
+    @staticmethod
+    def list_branch(notebook_id: str) -> List[BranchRow]:
+        dbfile = KishuResource.checkpoint_path(notebook_id)
+        con = sqlite3.connect(dbfile)
+        cur = con.cursor()
+        query = f"select branch_name, commit_id from {BRANCH_TABLE}"
+        cur.execute(query)
+        return [
+            BranchRow(branch_name=branch_name, commit_id=commit_id)
+            for branch_name, commit_id in cur
+        ]

--- a/kishu/kishu/checkpoint_io.py
+++ b/kishu/kishu/checkpoint_io.py
@@ -16,6 +16,8 @@ CHECKPOINT_TABLE = 'checkpoint'
 
 RESTORE_PLAN_TABLE = 'restore'
 
+BRANCH_TABLE = 'branch'
+
 
 def get_from_table(dbfile: str, table_name: str, commit_id: str) -> bytes:
     con = sqlite3.connect(dbfile)
@@ -44,6 +46,7 @@ def init_checkpoint_database(dbfile: str):
     cur.execute(f'create table if not exists {HISTORY_LOG_TABLE} (commit_id text primary key, data blob)')
     cur.execute(f'create table if not exists {CHECKPOINT_TABLE} (commit_id text primary key, data blob)')
     cur.execute(f'create table if not exists {RESTORE_PLAN_TABLE} (commit_id text primary key, data blob)')
+    cur.execute(f'create table if not exists {BRANCH_TABLE} (branch_name text primary key, commit_id text)')
 
 
 def store_log_item(dbfile: str, commit_id: str, data: bytes) -> None:

--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -15,11 +15,13 @@ Command Line Interface.
 
 class Command(enum.Enum):
     help = "help"
+
     log = "log"
     log_all = "log_all"
     status = "status"
 
     checkout = "checkout"
+    branch = "branch"
 
 
 @dataclasses.dataclass
@@ -28,6 +30,7 @@ class KishuCLIArguments:
     command: Command = Command.help  # Kishu command.
     notebook_id: Optional[str] = None  # Notebook ID to interact with.
     commit_id: Optional[str] = None  # Commit ID to apply command on.
+    branch_name: Optional[str] = None  # Branch name.
 
     @staticmethod
     def from_argv(argv: List[str]) -> KishuCLIArguments:
@@ -56,6 +59,7 @@ class KishuCLI:
             Command.log_all: self.log_all,
             Command.status: self.status,
             Command.checkout: self.checkout,
+            Command.branch: self.branch,
         }
 
     def exec(self, args):
@@ -87,6 +91,11 @@ class KishuCLI:
         assert args.notebook_id is not None, "checkout requires notebook_id."
         assert args.commit_id is not None, "checkout requires commit_id."
         print(into_json(KishuCommand.checkout(args.notebook_id, args.commit_id)))
+
+    def branch(self, args):
+        assert args.notebook_id is not None, "branch requires notebook_id."
+        assert args.branch_name is not None, "branch requires branch_name."
+        print(into_json(KishuCommand.branch(args.notebook_id, args.branch_name, args.commit_id)))
 
 
 if __name__ == "__main__":

--- a/kishu/kishu/resources.py
+++ b/kishu/kishu/resources.py
@@ -35,6 +35,10 @@ class KishuResource:
         return os.path.join(KishuResource.notebook_directory(notebook_id), "connection.json")
 
     @staticmethod
+    def head_path(notebook_id: str) -> str:
+        return os.path.join(KishuResource.notebook_directory(notebook_id), "head.json")
+
+    @staticmethod
     def _create_dir(dir: str) -> str:
         """
         Creates a new directory if not exists.

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -133,6 +133,13 @@ class TestKishuCommand:
             _restore_plan=status_result.cell_exec_info._restore_plan,  # Not tested
         )
 
+    def test_branch(self, notebook_id, basic_execution_ids):
+        branch_result = KishuCommand.branch(notebook_id, "at_head", None)
+        assert branch_result.status == "ok"
+
+        branch_result = KishuCommand.branch(notebook_id, "historical", basic_execution_ids[1])
+        assert branch_result.status == "ok"
+
     def test_fe_initialize(self, notebook_id, basic_execution_ids):
         fe_initialize_result = KishuCommand.fe_initialize(notebook_id)
         assert len(fe_initialize_result.histories) == 3


### PR DESCRIPTION
Branch = (branch name, commit ID)
- Stored as an SQLite table

HEAD branch
- Initialized as "empty"
- Always point to the latest commit ID, stepping forward at each commit
- If a branch is associated, the branch commit ID also steps forward with HEAD

Tested: manual CLI/backend test + new unit test 