### PR TITLE
Update result formats for frontend commands

### DIFF
--- a/kishu/kishu/backend.py
+++ b/kishu/kishu/backend.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request
 
 import json
 
@@ -44,13 +44,14 @@ def branch(notebook_id: str, branch_name: str):
     return into_json(branch_result)
 
 
-@app.get("/fe/initialize/<notebook_id>")
-def fe_initialize(notebook_id: str):
-    fe_initialize_result = KishuCommand.fe_initialize(notebook_id)
-    return into_json(fe_initialize_result)
+@app.get("/fe/commit_graph/<notebook_id>")
+def fe_commit_graph(notebook_id: str):
+    fe_commit_graph_result = KishuCommand.fe_commit_graph(notebook_id)
+    return into_json(fe_commit_graph_result)
 
 
-@app.get("/fe/history/<notebook_id>/<commit_id>")
-def fe_history(notebook_id: str, commit_id: str):
-    fe_history_result = KishuCommand.fe_history(notebook_id, commit_id)
-    return into_json(fe_history_result)
+@app.get("/fe/commit/<notebook_id>/<commit_id>")
+def fe_commit(notebook_id: str, commit_id: str):
+    vardepth = request.args.get('vardepth', default=1, type=int)
+    fe_commit_result = KishuCommand.fe_commit(notebook_id, commit_id, vardepth)
+    return into_json(fe_commit_result)

--- a/kishu/kishu/branch.py
+++ b/kishu/kishu/branch.py
@@ -66,7 +66,11 @@ class KishuBranch:
         con = sqlite3.connect(dbfile)
         cur = con.cursor()
         query = f"select branch_name, commit_id from {BRANCH_TABLE}"
-        cur.execute(query)
+        try:
+            cur.execute(query)
+        except sqlite3.OperationalError:
+            # No such table means no branch
+            return []
         return [
             BranchRow(branch_name=branch_name, commit_id=commit_id)
             for branch_name, commit_id in cur

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -5,7 +5,7 @@ from typing import Generator, List, Optional, Type
 from kishu.resources import KishuResource
 from kishu.jupyterint2 import CellExecInfo, KishuForJupyter
 from kishu.commit_graph import CommitInfo
-from kishu.commands import CommitSummary, KishuCommand, SelectedHistory
+from kishu.commands import CommitSummary, KishuCommand, SelectedCommit
 
 
 @pytest.fixture()
@@ -140,15 +140,16 @@ class TestKishuCommand:
         branch_result = KishuCommand.branch(notebook_id, "historical", basic_execution_ids[1])
         assert branch_result.status == "ok"
 
-    def test_fe_initialize(self, notebook_id, basic_execution_ids):
-        fe_initialize_result = KishuCommand.fe_initialize(notebook_id)
-        assert len(fe_initialize_result.histories) == 3
+    def test_fe_commit_graph(self, notebook_id, basic_execution_ids):
+        fe_commit_graph_result = KishuCommand.fe_commit_graph(notebook_id)
+        assert len(fe_commit_graph_result.commits) == 3
 
-    def test_fe_history(self, notebook_id, basic_execution_ids):
-        fe_history_result = KishuCommand.fe_history(notebook_id, basic_execution_ids[-1])
-        assert fe_history_result == SelectedHistory(
+    def test_fe_commit(self, notebook_id, basic_execution_ids):
+        fe_commit_result = KishuCommand.fe_commit(notebook_id, basic_execution_ids[-1], vardepth=0)
+        assert fe_commit_result == SelectedCommit(
             oid="3",
-            timestamp=fe_history_result.timestamp,  # Not tested
-            cells=fe_history_result.cells,  # Not tested
+            parent_oid="2",
+            timestamp=fe_commit_result.timestamp,  # Not tested
+            cells=fe_commit_result.cells,  # Not tested
             variables=[],
         )


### PR DESCRIPTION
Update formats accordingly to examples in `hanxi_fronend`
- Rename the two endpoints
- Rename some fields
- Add parent commit ID
- Recurse into variable members
- Show variable type
- Show variable size (if applicable)

Tested manually