### PR TITLE
Persist and read commit HEAD from storage

### DIFF
--- a/kishu/kishu/commands.py
+++ b/kishu/kishu/commands.py
@@ -5,7 +5,7 @@ import jupyter_client
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, cast
 
-from kishu.branch import BranchRow, KishuBranch
+from kishu.branch import BranchRow, HeadBranch, KishuBranch
 from kishu.commit_graph import CommitInfo, KishuCommitGraph
 from kishu.jupyterint2 import CellExecInfo, KishuForJupyter
 from kishu.plan import UnitExecution
@@ -94,6 +94,7 @@ FESelectedCommit = SelectedCommit
 @dataclass
 class FEInitializeResult:
     commits: List[HistoricalCommit]
+    head: Optional[HeadBranch]
 
 
 class KishuCommand:
@@ -185,12 +186,14 @@ class KishuCommand:
         commits = KishuCommand._toposort_commits(commits)
 
         # Retreives and applies branch names.
+        head_branch = KishuBranch.get_head(notebook_id)
         branches = KishuBranch.list_branch(notebook_id)
         commits = KishuCommand._rebranch_commit(commits, branches)
 
         # Combines everything.
         return FEInitializeResult(
             commits=commits,
+            head=head_branch,
         )
 
     @staticmethod

--- a/kishu/tests/test_commit_graph.py
+++ b/kishu/tests/test_commit_graph.py
@@ -85,6 +85,7 @@ class TestKishuCommitGraph:
             CommitInfo("2", "1"),
             CommitInfo("1", "")
         ]
+        assert graph.head() == "3"
 
         graph.step("4")
         graph.step("5")
@@ -95,6 +96,7 @@ class TestKishuCommitGraph:
             CommitInfo("2", "1"),
             CommitInfo("1", "")
         ]
+        assert graph.head() == "5"
 
         graph.jump("3")
         assert graph.list_history() == [
@@ -109,6 +111,7 @@ class TestKishuCommitGraph:
             CommitInfo("2", "1"),
             CommitInfo("1", "")
         ]
+        assert graph.head() == "3"
 
         graph.step("3_1")
         graph.step("3_2")
@@ -123,12 +126,14 @@ class TestKishuCommitGraph:
             CommitInfo("2", "1"),
             CommitInfo("1", "")
         ]
+        assert graph.head() == "3_4"
 
         # Jumps to non-existent commit, creating a new commit from empty state.
         graph.jump("A")
         assert graph.list_history() == [
             CommitInfo("A", "")
         ]
+        assert graph.head() == "A"
 
         graph.step("A_A")
         graph.step("A_B")
@@ -144,6 +149,7 @@ class TestKishuCommitGraph:
             CommitInfo("2", "1"),
             CommitInfo("1", "")
         ]
+        assert graph.head() == "A_B"
 
     def test_persist_on_file_after_reload(self, tmp_path):
         graph = KishuCommitGraph.new_on_file(str(tmp_path))
@@ -217,6 +223,7 @@ class TestKishuCommitGraph:
             CommitInfo("2", "1"),
             CommitInfo("1", "")
         ]
+        assert graph.head() == "A_B"
 
     @pytest.mark.parametrize(
         "mode",


### PR DESCRIPTION
- Persist commit ID at HEAD on the commit graph store for reattachment
- Read commit HEAD infos and return with FE endpoint

To be merged after #116 

Tested in unit tests and manual runs