### PR TITLE
Reduce GitHub Action usage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,8 +6,14 @@ name: test
 on:
   push:
     branches: [ main ]
+    paths:
+      - elastic/**
+      - ElasticNotebook.py
   pull_request:
     branches: [ main ]
+    paths:
+      - elastic/**
+      - ElasticNotebook.py
 
 jobs:
   build:

--- a/.github/workflows/test-kishu.yml
+++ b/.github/workflows/test-kishu.yml
@@ -6,8 +6,12 @@ name: test-kishu
 on:
   push:
     branches: [ main ]
+    paths:
+      - kishu/**
   pull_request:
     branches: [ main ]
+    paths:
+      - kishu/**
 
 jobs:
   build:

--- a/kishu/tests/test_commit_graph.py
+++ b/kishu/tests/test_commit_graph.py
@@ -240,7 +240,7 @@ class TestKishuCommitGraph:
         else:
             raise ValueError(f"Invalid mode= {mode}")
 
-        NUM_STEP = 10000
+        NUM_STEP = 1000
         for idx in range(NUM_STEP):
             graph.step(str(idx))
 

--- a/kishu/tests/test_idgraph2.py
+++ b/kishu/tests/test_idgraph2.py
@@ -34,11 +34,6 @@ def test_idgraph_numpy():
     assert idgraph1 == idgraph4
 
 
-def test_idgraph_pandas():
-    test_idgraph_pandas_Series()
-    test_idgraph_pandas_df()
-
-
 def test_idgraph_pandas_Series():
     """
         Test if idgraph is accurately generated for panda series
@@ -166,18 +161,13 @@ def test_idgraph_matplotlib():
     plt.close('all')
 
 
-def test_idgraph_seaborn():
-    test_idgraph_seaborn_displot()
-    test_idgraph_seaborn_scatterplot()
-
-
 def test_idgraph_seaborn_displot():
     """
         Test if idgraph is accurately generated for seaborn displot objects (figure-level object)
     """
     df = sns.load_dataset('penguins')
     plot1 = sns.displot(data=df, x="flipper_length_mm",
-                        y="bill_length_mm", kind="kde")
+                        y="bill_length_mm", kind="hist")
     plot1.set(xlabel="flipper_length_mm")
 
     idgraph1 = idgraph.get_object_state(plot1, {})

--- a/kishu/tests/test_nbexec.py
+++ b/kishu/tests/test_nbexec.py
@@ -1,5 +1,6 @@
-import os
+import pytest
 
+import os
 import numpy as np
 
 from kishu.nbexec import NotebookRunner
@@ -46,6 +47,7 @@ def test_notebookrunner_empty_cell_list():
     }
 
 
+@pytest.mark.skip(reason="Too expensive to run (~21s)")
 def test_notebookrunner_case_two():
     cell_indices = [i for i in range(27)]
     path_to_notebook = os.getcwd()
@@ -75,6 +77,7 @@ def test_notebookrunner_case_two():
         assert np.array_equal(output[key], expected[key])
 
 
+@pytest.mark.skip(reason="Too expensive to run (~3s)")
 def test_notebookrunner_case_three():
     path_to_notebook = os.getcwd()
     notebook_name = "nbexec_test_case_3.ipynb"


### PR DESCRIPTION
We have ~800min left on GitHub Action until Oct 1. Some of these tests are running for too long.
- Cut and tune down unit tests whose duration is longer than 3 seconds
- Run workflow(s) if there is a change in respective paths