### PR TITLE
Fetch and show commit list on checkout command palette

### DIFF
--- a/kishu/jupyterlab_kishu/.eslintrc.cjs
+++ b/kishu/jupyterlab_kishu/.eslintrc.cjs
@@ -1,0 +1,12 @@
+/* eslint-env node */
+module.exports = {
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  root: true,
+  rules: {
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-namespace": "off"
+  },
+};

--- a/kishu/jupyterlab_kishu/jupyterlab_kishu/handlers.py
+++ b/kishu/jupyterlab_kishu/jupyterlab_kishu/handlers.py
@@ -1,32 +1,23 @@
 from __future__ import annotations
-import dataclasses
-import json
 import tornado
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 
 from kishu.commands import KishuCommand
+from kishu.serialization import into_json
 
 
-class DataclassJSONEncoder(json.JSONEncoder):
-
-    def default(self, o):
-        if dataclasses.is_dataclass(o):
-            return dataclasses.asdict(o)
-        try:
-            return super().default(o)
-        except TypeError:
-            return o.__repr__()
-
-
-def into_json(data):
-    return json.dumps(data, cls=DataclassJSONEncoder, indent=2)
+class LogAllHandler(APIHandler):
+    @tornado.web.authenticated
+    def post(self):
+        input_data = self.get_json_body()
+        log_all_result = KishuCommand.log_all(input_data["notebook_id"])
+        self.finish(into_json(log_all_result))
 
 
 class CheckoutHandler(APIHandler):
     @tornado.web.authenticated
     def post(self):
-        # input_data is a dictionary with a key "name"
         input_data = self.get_json_body()
         checkout_result = KishuCommand.checkout(input_data["notebook_id"], input_data["commit_id"])
         self.finish(into_json(checkout_result))
@@ -34,14 +25,10 @@ class CheckoutHandler(APIHandler):
 
 def setup_handlers(web_app):
     host_pattern = ".*$"
-
     base_url = web_app.settings["base_url"]
     kishu_url = url_path_join(base_url, "kishu")
-
-    """
-    Checkout
-    """
-
-    route_pattern = url_path_join(kishu_url, "checkout")
-    handlers = [(route_pattern, CheckoutHandler)]
+    handlers = [
+        (url_path_join(kishu_url, "log_all"), LogAllHandler),
+        (url_path_join(kishu_url, "checkout"), CheckoutHandler),
+    ]
     web_app.add_handlers(host_pattern, handlers)

--- a/kishu/jupyterlab_kishu/package.json
+++ b/kishu/jupyterlab_kishu/package.json
@@ -56,8 +56,8 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
-        "@jupyterlab/application": "^4.0.0",
-        "@jupyterlab/settingregistry": "^4.0.0"
+        "@jupyterlab/application": "^3.1.6 || ^4.0.0",
+        "@jupyterlab/settingregistry": "^3.1.6 || ^4.0.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",
@@ -66,10 +66,10 @@
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",
         "@types/react-addons-linked-state-mixin": "^0.14.22",
-        "@typescript-eslint/eslint-plugin": "^6.1.0",
-        "@typescript-eslint/parser": "^6.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.3",
+        "@typescript-eslint/parser": "^6.7.3",
         "css-loader": "^6.7.1",
-        "eslint": "^8.36.0",
+        "eslint": "^8.50.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.2.0",
@@ -83,7 +83,7 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
-        "typescript": "~5.0.2",
+        "typescript": "^5.2.2",
         "yjs": "^13.5.0"
     },
     "sideEffects": [

--- a/kishu/jupyterlab_kishu/src/handler.ts
+++ b/kishu/jupyterlab_kishu/src/handler.ts
@@ -25,22 +25,18 @@ export async function requestAPI<T>(
   try {
     response = await ServerConnection.makeRequest(requestUrl, init, settings);
   } catch (error) {
-    throw new ServerConnection.NetworkError(error as any);
+    throw new ServerConnection.NetworkError(error as TypeError);
   }
-
-  let data: any = await response.text();
-
+  const data: string = await response.text();
+  if (!response.ok) {
+    throw new ServerConnection.ResponseError(response, data);
+  }
   if (data.length > 0) {
     try {
-      data = JSON.parse(data);
+      return JSON.parse(data);
     } catch (error) {
       console.log('Not a JSON response body.', response);
     }
   }
-
-  if (!response.ok) {
-    throw new ServerConnection.ResponseError(response, data.message || data);
-  }
-
-  return data;
+  throw new ServerConnection.ResponseError(response, data);
 }

--- a/kishu/jupyterlab_kishu/src/index.ts
+++ b/kishu/jupyterlab_kishu/src/index.ts
@@ -18,9 +18,36 @@ namespace CommandIDs {
   export const checkout = 'kishu:checkout';
 }
 
+
+interface CommitSummary {
+    commit_id: string;
+    parent_id: string;
+    message: string;
+    timestamp: string;
+    code_block?: string;
+    runtime_ms?: number;
+  }
+
+interface LogAllResult {
+    commit_graph: CommitSummary[];
+}
+
 interface CheckoutResult {
-    status: string,
-    message: string,
+    status: string;
+    message: string;
+}
+
+function commitSummaryToString(commit: CommitSummary): string {
+  return `[${commit.commit_id}] ${commit.message}`;
+}
+
+function extractHashFromString(inputString: string): string | undefined {
+  const regex = /\[([a-fA-F0-9-]+)\]\s/;
+  const match = inputString.match(regex);
+  if (match && match[1]) {
+    return match[1];
+  }
+  return undefined;
 }
 
 /**
@@ -58,9 +85,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     commands.addCommand(CommandIDs.checkout, {
       label: trans.__('Kishu: Checkout...'),
-      execute: async (args: any) => {
-        // Ask for inputs.
-        let notebook_id = (
+      execute: async (_args) => {
+        // TODO: Detect currently viewed notebook path.
+        const notebook_id = (
           await InputDialog.getText({
             placeholder: '<notebook_id>',
             title: trans.__('Checkout...'),
@@ -71,32 +98,57 @@ const plugin: JupyterFrontEndPlugin<void> = {
           window.alert(trans.__(`Kishu checkout requires notebook ID.`));
           return;
         }
-        let commit_id = (
-          await InputDialog.getText({
-            placeholder: '<commit_id>',
-            title: trans.__('Checkout to...'),
-            okLabel: trans.__('Checkout')
-          })
-        ).value ?? undefined;
+
+        // List all commits.
+        const log_all_result = await requestAPI<LogAllResult>('log_all', {
+          method: 'POST',
+          body: JSON.stringify({notebook_id: notebook_id}),
+        });
+
+        // Ask for the target commit ID.
+        let commit_id = undefined;
+        if (!log_all_result || log_all_result.commit_graph.length == 0) {
+          // Failed to list, asking in text dialog directly.
+          commit_id = (
+            await InputDialog.getText({
+              placeholder: '<commit_id>',
+              title: trans.__('Checkout to...'),
+              okLabel: trans.__('Checkout')
+            })
+          ).value ?? undefined;
+        } else {
+          // Show the list and ask to pick one item
+          const selected_commit_str = (
+            await InputDialog.getItem({
+              items: log_all_result.commit_graph.map(commitSummaryToString),
+              current: log_all_result.commit_graph.length - 1,
+              editable: false,
+              title: trans.__('Checkout to...'),
+              okLabel: trans.__('Checkout')
+            })
+          ).value ?? undefined;
+          if (selected_commit_str !== undefined) {
+            console.log(`Selected selected_commit_str= ${selected_commit_str}`);
+            commit_id = extractHashFromString(selected_commit_str);
+          }
+        }
         if (!commit_id) {
           window.alert(trans.__(`Kishu checkout requires commit ID.`));
           return;
         }
+        console.log(`Selected commit_id= ${commit_id}`);
 
         // Make checkout request
-        let checkout_result = await requestAPI<CheckoutResult>('checkout', {
+        const checkout_result = await requestAPI<CheckoutResult>('checkout', {
           method: 'POST',
-          body: JSON.stringify({
-            notebook_id: notebook_id,
-            commit_id: commit_id,
-          }),
+          body: JSON.stringify({notebook_id: notebook_id, commit_id: commit_id}),
         });
 
         // Report.
         if (checkout_result.status != 'ok') {
           window.alert(trans.__(`Kishu checkout failed: "${checkout_result.message}"`));
         } else {
-          window.alert(trans.__(`Kishu checkout to ${commit_id} succeeded. Please refresh this page.`));
+          window.alert(trans.__(`Kishu checkout to ${commit_id} succeeded.\nPlease refresh this page.`));
         }
       }
     });

--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -37,7 +37,11 @@ Kishu Commands.
 
 @kishu_app.command()
 def log(
-    notebook_id: str = typer.Argument(help="Notebook ID to interact with.", show_default=False),
+    notebook_id: str = typer.Argument(
+        ...,
+        help="Notebook ID to interact with.",
+        show_default=False
+    ),
     commit_id: str = typer.Argument(
         None,
         help="Show the history of a commit ID.",
@@ -61,8 +65,12 @@ def log(
 
 @kishu_app.command()
 def status(
-    notebook_id: str = typer.Argument(help="Notebook ID to interact with.", show_default=False),
-    commit_id: str = typer.Argument(help="Commit ID to get status.", show_default=False),
+    notebook_id: str = typer.Argument(
+        ...,
+        help="Notebook ID to interact with.",
+        show_default=False
+    ),
+    commit_id: str = typer.Argument(..., help="Commit ID to get status.", show_default=False),
 ) -> None:
     """
     Show a commit in detail.
@@ -72,7 +80,11 @@ def status(
 
 @kishu_app.command()
 def commit(
-    notebook_id: str = typer.Argument(help="Notebook ID to interact with.", show_default=False),
+    notebook_id: str = typer.Argument(
+        ...,
+        help="Notebook ID to interact with.",
+        show_default=False
+    ),
     message: str = typer.Option(
         None,
         "-m",
@@ -89,8 +101,13 @@ def commit(
 
 @kishu_app.command()
 def checkout(
-    notebook_id: str = typer.Argument(help="Notebook ID to interact with.", show_default=False),
+    notebook_id: str = typer.Argument(
+        ...,
+        help="Notebook ID to interact with.",
+        show_default=False
+    ),
     branch_or_commit_id: str = typer.Argument(
+        ...,
         help="Branch name or commit ID to checkout.",
         show_default=False,
     ),
@@ -103,7 +120,11 @@ def checkout(
 
 @kishu_app.command()
 def branch(
-    notebook_id: str = typer.Argument(help="Notebook ID to interact with.", show_default=False),
+    notebook_id: str = typer.Argument(
+        ...,
+        help="Notebook ID to interact with.",
+        show_default=False
+    ),
     commit_id: str = typer.Argument(
         None,
         help="Commit ID to create the branch on.",

--- a/kishu/kishu/commands.py
+++ b/kishu/kishu/commands.py
@@ -16,6 +16,7 @@ class CommitSummary:
     commit_id: str
     parent_id: str
     message: str
+    timestamp: str
     code_block: Optional[str]
     runtime_ms: Optional[int]
 
@@ -200,7 +201,7 @@ class KishuCommand:
             commits.append(HistoricalCommit(
                 oid=node.commit_id,
                 parent_oid=node.parent_id,
-                timestamp=KishuCommand._to_datetime(commit_entry.end_time_ms),
+                timestamp=KishuCommand._to_datetime(commit_entry.timestamp_ms),
                 branch_id="",  # To be set in _toposort_commits.
                 parent_branch_id="",  # To be set in _toposort_commits.
                 other_branch_ids=[],
@@ -266,6 +267,7 @@ class KishuCommand:
                 commit_id=node.commit_id,
                 parent_id=node.parent_id,
                 message=commit_entry.message,
+                timestamp=KishuCommand._to_datetime(commit_entry.timestamp_ms),
                 code_block=commit_entry.code_block,
                 runtime_ms=commit_entry.runtime_ms,
             ))
@@ -308,7 +310,7 @@ class KishuCommand:
         return SelectedCommit(
             oid=commit_id,
             parent_oid=commit_node_info.parent_id,
-            timestamp=KishuCommand._to_datetime(commit_entry.end_time_ms),
+            timestamp=KishuCommand._to_datetime(commit_entry.timestamp_ms),
             latest_exec_num=KishuCommand._str_or_none(commit_entry.execution_count),
             variables=variables,
             cells=cells,

--- a/kishu/kishu/jupyterint2.py
+++ b/kishu/kishu/jupyterint2.py
@@ -208,10 +208,11 @@ class CommitEntry(UnitExecution):
     raw_nb: Optional[str] = None
     formatted_cells: Optional[List[FormattedCell]] = None
     restore_plan: Optional[RestorePlan] = None
+    message: str = ""
+    timestamp_ms: int = 0
 
     # Only available in jupyter commit entries
     execution_count: Optional[int] = None
-    message: str = ""
     error_before_exec: Optional[str] = None
     error_in_exec: Optional[str] = None
     result: Optional[str] = None
@@ -511,8 +512,9 @@ class KishuForJupyter:
         return BareReprStr(entry.exec_id)
 
     def _commit_entry(self, entry: CommitEntry) -> None:
-        # Generate commit ID/
+        # Generate commit ID.
         entry.exec_id = self._commit_id()
+        entry.timestamp_ms = get_epoch_time_ms()
 
         # Force saving to observe all cells and extract notebook informations.
         self._save_notebook()

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -69,6 +69,7 @@ class TestKishuCommand:
             commit_id="0:3",
             parent_id="0:2",
             message=log_result.commit_graph[0].message,  # Not tested
+            timestamp=log_result.commit_graph[0].timestamp,  # Not tested
             code_block="y = x + 1",
             runtime_ms=log_result.commit_graph[0].runtime_ms,  # Not tested
         )
@@ -76,6 +77,7 @@ class TestKishuCommand:
             commit_id="0:2",
             parent_id="0:1",
             message=log_result.commit_graph[1].message,  # Not tested
+            timestamp=log_result.commit_graph[1].timestamp,  # Not tested
             code_block="y = 2",
             runtime_ms=log_result.commit_graph[1].runtime_ms,  # Not tested
         )
@@ -83,6 +85,7 @@ class TestKishuCommand:
             commit_id="0:1",
             parent_id="",
             message=log_result.commit_graph[2].message,  # Not tested
+            timestamp=log_result.commit_graph[2].timestamp,  # Not tested
             code_block="x = 1",
             runtime_ms=log_result.commit_graph[2].runtime_ms,  # Not tested
         )
@@ -93,6 +96,7 @@ class TestKishuCommand:
             commit_id="0:1",
             parent_id="",
             message=log_result.commit_graph[0].message,  # Not tested
+            timestamp=log_result.commit_graph[0].timestamp,  # Not tested
             code_block="x = 1",
             runtime_ms=log_result.commit_graph[0].runtime_ms,  # Not tested
         )
@@ -104,6 +108,7 @@ class TestKishuCommand:
             commit_id="0:1",
             parent_id="",
             message=log_all_result.commit_graph[0].message,  # Not tested
+            timestamp=log_all_result.commit_graph[0].timestamp,  # Not tested
             code_block="x = 1",
             runtime_ms=log_all_result.commit_graph[0].runtime_ms,  # Not tested
         )
@@ -111,6 +116,7 @@ class TestKishuCommand:
             commit_id="0:2",
             parent_id="0:1",
             message=log_all_result.commit_graph[1].message,  # Not tested
+            timestamp=log_all_result.commit_graph[1].timestamp,  # Not tested
             code_block="y = 2",
             runtime_ms=log_all_result.commit_graph[1].runtime_ms,  # Not tested
         )
@@ -118,6 +124,7 @@ class TestKishuCommand:
             commit_id="0:3",
             parent_id="0:2",
             message=log_all_result.commit_graph[2].message,  # Not tested
+            timestamp=log_all_result.commit_graph[2].timestamp,  # Not tested
             code_block="y = x + 1",
             runtime_ms=log_all_result.commit_graph[2].runtime_ms,  # Not tested
         )
@@ -135,6 +142,7 @@ class TestKishuCommand:
             code_block="y = x + 1",
             checkpoint_vars=[],
             message=status_result.commit_entry.message,  # Not tested,
+            timestamp_ms=status_result.commit_entry.timestamp_ms,  # Not tested
             start_time_ms=status_result.commit_entry.start_time_ms,  # Not tested
             end_time_ms=status_result.commit_entry.end_time_ms,  # Not tested
             checkpoint_runtime_ms=status_result.commit_entry.checkpoint_runtime_ms,  # Not tested

--- a/kishu/tests/test_jupyterint2.py
+++ b/kishu/tests/test_jupyterint2.py
@@ -83,6 +83,7 @@ def test_record_history():
 
     def replace_start_time(commit_entry):
         set_field_to(commit_entry, 'checkpoint_runtime_ms', 0)
+        set_field_to(commit_entry, 'timestamp_ms', 0)
         set_field_to(commit_entry, 'end_time_ms', 0)
         set_field_to(commit_entry, 'runtime_ms', 0)
         set_field_to(commit_entry, 'start_time_ms', 0)
@@ -99,6 +100,7 @@ def test_record_history():
             "execution_count": 1,
             "kind": "jupyter",
             "message": "",
+            "timestamp_ms": 0,
         }
     assert replace_start_time(history_dict['0:2']) == {
             "checkpoint_runtime_ms": 0,
@@ -111,4 +113,5 @@ def test_record_history():
             "start_time_ms": 0,
             "kind": "jupyter",
             "message": "",
+            "timestamp_ms": 0,
         }


### PR DESCRIPTION
- Always capture commit time in commit entry
- Fetch list of commits during command palette checkout through `log_all`
- Display and prompt as an item list dialog

Also...
- Fix compatibility with older Typer

Tested manually on local JupyterLab and Notebook 7