### PR TITLE
Implement tag to a commit with message

### DIFF
--- a/kishu/kishu/backend.py
+++ b/kishu/kishu/backend.py
@@ -50,6 +50,14 @@ def branch(notebook_id: str, branch_name: str):
     return into_json(branch_result)
 
 
+@app.get("/tag/<notebook_id>/<tag_name>")
+def tag(notebook_id: str, tag_name: str):
+    commit_id: Optional[str] = request.args.get('commit_id', default=None, type=str)
+    message: str = request.args.get('message', default="", type=str)
+    tag_result = KishuCommand.tag(notebook_id, tag_name, commit_id, message)
+    return into_json(tag_result)
+
+
 @app.get("/fe/commit_graph/<notebook_id>")
 def fe_commit_graph(notebook_id: str):
     fe_commit_graph_result = KishuCommand.fe_commit_graph(notebook_id)

--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -163,6 +163,35 @@ def branch(
             raise typer.Exit()
 
 
+@kishu_app.command()
+def tag(
+    notebook_id: str = typer.Argument(
+        ...,
+        help="Notebook ID to interact with.",
+        show_default=False
+    ),
+    tag_name: str = typer.Argument(
+        ...,
+        help="Tag name.",
+        show_default=False,
+    ),
+    commit_id: str = typer.Argument(
+        None,
+        help="Commit ID to create the tag on. If not given, use the current commit ID.",
+        show_default=False,
+    ),
+    message: str = typer.Option(
+        "",
+        "-m",
+        help="Message to annotate the tag with.",
+    ),
+) -> None:
+    """
+    Create or edit tags.
+    """
+    print(into_json(KishuCommand.tag(notebook_id, tag_name, commit_id, message)))
+
+
 def main() -> None:
     kishu_app(prog_name=__app_name__)
 

--- a/kishu/kishu/storage/checkpoint_io.py
+++ b/kishu/kishu/storage/checkpoint_io.py
@@ -18,6 +18,8 @@ RESTORE_PLAN_TABLE = 'restore'
 
 BRANCH_TABLE = 'branch'
 
+TAG_TABLE = 'tag'
+
 
 def get_from_table(dbfile: str, table_name: str, commit_id: str) -> bytes:
     con = sqlite3.connect(dbfile)
@@ -47,6 +49,7 @@ def init_checkpoint_database(dbfile: str):
     cur.execute(f'create table if not exists {CHECKPOINT_TABLE} (commit_id text primary key, data blob)')
     cur.execute(f'create table if not exists {RESTORE_PLAN_TABLE} (commit_id text primary key, data blob)')
     cur.execute(f'create table if not exists {BRANCH_TABLE} (branch_name text primary key, commit_id text)')
+    cur.execute(f'create table if not exists {TAG_TABLE} (tag_name text primary key, commit_id text, message text)')
 
 
 def store_log_item(dbfile: str, commit_id: str, data: bytes) -> None:

--- a/kishu/kishu/storage/tag.py
+++ b/kishu/kishu/storage/tag.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sqlite3
+
+from dataclasses import dataclass
+from typing import List
+
+from kishu.storage.checkpoint_io import TAG_TABLE
+from kishu.storage.path import KishuPath
+
+
+@dataclass
+class TagRow:
+    tag_name: str
+    commit_id: str
+    message: str
+
+
+class KishuTag:
+
+    @staticmethod
+    def upsert_tag(notebook_id: str, tag: TagRow) -> None:
+        dbfile = KishuPath.checkpoint_path(notebook_id)
+        con = sqlite3.connect(dbfile)
+        cur = con.cursor()
+        query = f"insert or replace into {TAG_TABLE} values (?, ?, ?)"
+        cur.execute(query, (tag.tag_name, tag.commit_id, tag.message))
+        con.commit()
+
+    @staticmethod
+    def list_tag(notebook_id: str) -> List[TagRow]:
+        dbfile = KishuPath.checkpoint_path(notebook_id)
+        con = sqlite3.connect(dbfile)
+        cur = con.cursor()
+        query = f"select tag_name, commit_id, message from {TAG_TABLE}"
+        try:
+            cur.execute(query)
+        except sqlite3.OperationalError:
+            # No such table means no tag
+            return []
+        return [
+            TagRow(tag_name=tag_name, commit_id=commit_id, message=message)
+            for tag_name, commit_id, message in cur
+        ]

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -187,6 +187,19 @@ class TestKishuCommand:
             notebook_id, branch_1, branch_1)
         assert rename_branch_result.status == "error"
 
+    def test_tag(self, notebook_id, basic_execution_ids):
+        tag_result = KishuCommand.tag(notebook_id, "athead", None, "In current time")
+        assert tag_result.status == "ok"
+        assert tag_result.tag_name == "athead"
+        assert tag_result.commit_id == basic_execution_ids[-1]
+        assert tag_result.message == "In current time"
+
+        tag_result = KishuCommand.tag(notebook_id, "historical", basic_execution_ids[1], "")
+        assert tag_result.status == "ok"
+        assert tag_result.tag_name == "historical"
+        assert tag_result.commit_id == basic_execution_ids[1]
+        assert tag_result.message == ""
+
     def test_fe_commit_graph(self, notebook_id, basic_execution_ids):
         fe_commit_graph_result = KishuCommand.fe_commit_graph(notebook_id)
         assert len(fe_commit_graph_result.commits) == 3


### PR DESCRIPTION
- Create tag table
- Upsert tag with name, commit ID, and message
- Implement tag command
- Enable on CLI and backend
- Join tag list on FE commit-graph endpoint

This is equivalent to annotated tag in git.

Tested in unit test + manually