### PR TITLE
List branches and tags in log commands

### DIFF
--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -68,12 +68,14 @@ class TestKishuCommand:
         log_result = KishuCommand.log(notebook_id, basic_execution_ids[-1])
         assert len(log_result.commit_graph) == 3
         assert log_result.commit_graph[0] == CommitSummary(
-            commit_id="0:3",
-            parent_id="0:2",
+            commit_id="0:1",
+            parent_id="",
             message=log_result.commit_graph[0].message,  # Not tested
             timestamp=log_result.commit_graph[0].timestamp,  # Not tested
-            code_block="y = x + 1",
+            code_block="x = 1",
             runtime_ms=log_result.commit_graph[0].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
         )
         assert log_result.commit_graph[1] == CommitSummary(
             commit_id="0:2",
@@ -82,14 +84,18 @@ class TestKishuCommand:
             timestamp=log_result.commit_graph[1].timestamp,  # Not tested
             code_block="y = 2",
             runtime_ms=log_result.commit_graph[1].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
         )
         assert log_result.commit_graph[2] == CommitSummary(
-            commit_id="0:1",
-            parent_id="",
+            commit_id="0:3",
+            parent_id="0:2",
             message=log_result.commit_graph[2].message,  # Not tested
             timestamp=log_result.commit_graph[2].timestamp,  # Not tested
-            code_block="x = 1",
+            code_block="y = x + 1",
             runtime_ms=log_result.commit_graph[2].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
         )
 
         log_result = KishuCommand.log(notebook_id, basic_execution_ids[0])
@@ -101,6 +107,8 @@ class TestKishuCommand:
             timestamp=log_result.commit_graph[0].timestamp,  # Not tested
             code_block="x = 1",
             runtime_ms=log_result.commit_graph[0].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
         )
 
     def test_log_all(self, notebook_id, basic_execution_ids):
@@ -113,6 +121,8 @@ class TestKishuCommand:
             timestamp=log_all_result.commit_graph[0].timestamp,  # Not tested
             code_block="x = 1",
             runtime_ms=log_all_result.commit_graph[0].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
         )
         assert log_all_result.commit_graph[1] == CommitSummary(
             commit_id="0:2",
@@ -121,6 +131,8 @@ class TestKishuCommand:
             timestamp=log_all_result.commit_graph[1].timestamp,  # Not tested
             code_block="y = 2",
             runtime_ms=log_all_result.commit_graph[1].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
         )
         assert log_all_result.commit_graph[2] == CommitSummary(
             commit_id="0:3",
@@ -129,6 +141,8 @@ class TestKishuCommand:
             timestamp=log_all_result.commit_graph[2].timestamp,  # Not tested
             code_block="y = x + 1",
             runtime_ms=log_all_result.commit_graph[2].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
         )
 
     def test_status(self, notebook_id, basic_execution_ids):
@@ -162,6 +176,42 @@ class TestKishuCommand:
         branch_result = KishuCommand.branch(notebook_id, "historical", basic_execution_ids[1])
         assert branch_result.status == "ok"
 
+    def test_branch_log(self, notebook_id, basic_execution_ids):
+        _ = KishuCommand.branch(notebook_id, "at_head", None)
+        _ = KishuCommand.branch(notebook_id, "historical", basic_execution_ids[1])
+        log_result = KishuCommand.log(notebook_id, basic_execution_ids[-1])
+        assert len(log_result.commit_graph) == 3
+        assert log_result.commit_graph[0] == CommitSummary(
+            commit_id="0:1",
+            parent_id="",
+            message=log_result.commit_graph[0].message,  # Not tested
+            timestamp=log_result.commit_graph[0].timestamp,  # Not tested
+            code_block="x = 1",
+            runtime_ms=log_result.commit_graph[0].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
+        )
+        assert log_result.commit_graph[1] == CommitSummary(
+            commit_id="0:2",
+            parent_id="0:1",
+            message=log_result.commit_graph[1].message,  # Not tested
+            timestamp=log_result.commit_graph[1].timestamp,  # Not tested
+            code_block="y = 2",
+            runtime_ms=log_result.commit_graph[1].runtime_ms,  # Not tested
+            branches=["historical"],
+            tags=[],
+        )
+        assert log_result.commit_graph[2] == CommitSummary(
+            commit_id="0:3",
+            parent_id="0:2",
+            message=log_result.commit_graph[2].message,  # Not tested
+            timestamp=log_result.commit_graph[2].timestamp,  # Not tested
+            code_block="y = x + 1",
+            runtime_ms=log_result.commit_graph[2].runtime_ms,  # Not tested
+            branches=["at_head"],
+            tags=[],
+        )
+
     def test_rename_branch_basic(self, notebook_id, basic_execution_ids):
         branch_1 = "branch_1"
         KishuCommand.branch(notebook_id, branch_1, None)
@@ -188,9 +238,9 @@ class TestKishuCommand:
         assert rename_branch_result.status == "error"
 
     def test_tag(self, notebook_id, basic_execution_ids):
-        tag_result = KishuCommand.tag(notebook_id, "athead", None, "In current time")
+        tag_result = KishuCommand.tag(notebook_id, "at_head", None, "In current time")
         assert tag_result.status == "ok"
-        assert tag_result.tag_name == "athead"
+        assert tag_result.tag_name == "at_head"
         assert tag_result.commit_id == basic_execution_ids[-1]
         assert tag_result.message == "In current time"
 
@@ -199,6 +249,42 @@ class TestKishuCommand:
         assert tag_result.tag_name == "historical"
         assert tag_result.commit_id == basic_execution_ids[1]
         assert tag_result.message == ""
+
+    def test_tag_log(self, notebook_id, basic_execution_ids):
+        _ = KishuCommand.tag(notebook_id, "at_head", None, "In current time")
+        _ = KishuCommand.tag(notebook_id, "historical", basic_execution_ids[1], "")
+        log_result = KishuCommand.log(notebook_id, basic_execution_ids[-1])
+        assert len(log_result.commit_graph) == 3
+        assert log_result.commit_graph[0] == CommitSummary(
+            commit_id="0:1",
+            parent_id="",
+            message=log_result.commit_graph[0].message,  # Not tested
+            timestamp=log_result.commit_graph[0].timestamp,  # Not tested
+            code_block="x = 1",
+            runtime_ms=log_result.commit_graph[0].runtime_ms,  # Not tested
+            branches=[],
+            tags=[],
+        )
+        assert log_result.commit_graph[1] == CommitSummary(
+            commit_id="0:2",
+            parent_id="0:1",
+            message=log_result.commit_graph[1].message,  # Not tested
+            timestamp=log_result.commit_graph[1].timestamp,  # Not tested
+            code_block="y = 2",
+            runtime_ms=log_result.commit_graph[1].runtime_ms,  # Not tested
+            branches=[],
+            tags=["historical"],
+        )
+        assert log_result.commit_graph[2] == CommitSummary(
+            commit_id="0:3",
+            parent_id="0:2",
+            message=log_result.commit_graph[2].message,  # Not tested
+            timestamp=log_result.commit_graph[2].timestamp,  # Not tested
+            code_block="y = x + 1",
+            runtime_ms=log_result.commit_graph[2].runtime_ms,  # Not tested
+            branches=[],
+            tags=["at_head"],
+        )
 
     def test_fe_commit_graph(self, notebook_id, basic_execution_ids):
         fe_commit_graph_result = KishuCommand.fe_commit_graph(notebook_id)


### PR DESCRIPTION
- Also query branch and tag tables in `kishu log` and `kishu log --log_all` commands
- Sort by timestamp ascending

Tested in unit tests