### PR TITLE
Checkout skip notebook recovery optionally

### DIFF
--- a/kishu/kishu/backend.py
+++ b/kishu/kishu/backend.py
@@ -38,7 +38,12 @@ def status(notebook_id: str, commit_id: str):
 
 @app.get("/checkout/<notebook_id>/<branch_or_commit_id>")
 def checkout(notebook_id: str, branch_or_commit_id: str):
-    checkout_result = KishuCommand.checkout(notebook_id, branch_or_commit_id)
+    skip_notebook: bool = request.args.get('skip_notebook', default=False, type=is_true)
+    checkout_result = KishuCommand.checkout(
+        notebook_id,
+        branch_or_commit_id,
+        skip_notebook=skip_notebook,
+    )
     return into_json(checkout_result)
 
 

--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -114,11 +114,21 @@ def checkout(
         help="Branch name or commit ID to checkout.",
         show_default=False,
     ),
+    skip_notebook: bool = typer.Option(
+        False,
+        "--skip-notebook",
+        "--skip_notebook",
+        help="Skip recovering notebook cells and outputs.",
+    )
 ) -> None:
     """
     Checkout a notebook to a commit.
     """
-    print(into_json(KishuCommand.checkout(notebook_id, branch_or_commit_id)))
+    print(into_json(KishuCommand.checkout(
+        notebook_id,
+        branch_or_commit_id,
+        skip_notebook=skip_notebook,
+    )))
 
 
 @kishu_app.command()
@@ -137,6 +147,7 @@ def branch(
         None,
         "-c",
         "--create-branch-name",
+        "--create_branch_name",
         help="Create branch with this name.",
         show_default=False,
     ),
@@ -144,6 +155,7 @@ def branch(
         (None, None),
         "-m",
         "--rename-branch",
+        "--rename_branch",
         help="Rename branch from old name to new name.",
         show_default=False,
     ),

--- a/kishu/kishu/commands.py
+++ b/kishu/kishu/commands.py
@@ -144,6 +144,7 @@ class KishuCommand:
         if commit_id is None:
             head = KishuBranch.get_head(notebook_id)
             commit_id = head.commit_id
+            print(commit_id)
 
         if commit_id is None:
             return LogResult([])
@@ -176,14 +177,15 @@ class KishuCommand:
         return JupyterConnection.execute_one_command(notebook_id, command)
 
     @staticmethod
-    def checkout(notebook_id: str, branch_or_commit_id: str) -> CheckoutResult:
-        result = JupyterConnection.execute_one_command(
+    def checkout(
+        notebook_id: str,
+        branch_or_commit_id: str,
+        skip_notebook: bool = False,
+    ) -> CheckoutResult:
+        return JupyterConnection.execute_one_command(
             notebook_id,
-            f"_kishu.checkout('{branch_or_commit_id}')",
+            f"_kishu.checkout('{branch_or_commit_id}', skip_notebook={skip_notebook})",
         )
-        if result.status == "ok":
-            result.message = f"Checkout {branch_or_commit_id}"
-        return result
 
     @staticmethod
     def branch(

--- a/kishu/kishu/storage/branch.py
+++ b/kishu/kishu/storage/branch.py
@@ -42,13 +42,22 @@ class KishuBranch:
         commit_id: Optional[str] = None,
         is_detach: bool = False
     ) -> HeadBranch:
+        # Get current head.
         head = KishuBranch.get_head(notebook_id)
         if head is None:
             head = HeadBranch(branch_name=None, commit_id=None)
-        if branch_name is not None or is_detach:
+
+        # Assign head branch.
+        if is_detach:
+            head.branch_name = None
+        elif branch_name is not None:
             head.branch_name = branch_name
+
+        # Assign commit ID.
         if commit_id is not None:
             head.commit_id = commit_id
+
+        # Write head.
         with open(KishuPath.head_path(notebook_id), 'w') as f:
             f.write(head.to_json())  # type: ignore
         return head


### PR DESCRIPTION
- Add an option to checkout only the variables, i.e. skipping notebook cell recovery
- Improve `JupyterConnection` output parser
- Improve response from `checkout`

Tested manually