### PR TITLE
Store executed cells in each commit

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -207,6 +207,7 @@ class CommitEntry(UnitExecution):
 
     checkpoint_runtime_ms: Optional[int] = None
     checkpoint_vars: Optional[List[str]] = None
+    executed_cells: Optional[List[str]] = None
     raw_nb: Optional[str] = None
     formatted_cells: Optional[List[FormattedCell]] = None
     restore_plan: Optional[RestorePlan] = None
@@ -366,8 +367,8 @@ class KishuForJupyter:
         self._start_time_ms: Optional[int] = None
 
         self._cr_planner = CheckpointRestorePlanner(
-            {} if get_jupyter_kernel() is None
-            else get_jupyter_kernel().user_ns
+            {} if kishu_ipython() is None
+            else kishu_ipython().user_ns
         )
 
     def set_test_mode(self):
@@ -384,7 +385,7 @@ class KishuForJupyter:
         return KishuPath.checkpoint_path(self._notebook_id)
 
     def get_user_namespace_vars(self) -> Set[str]:
-        ip = get_jupyter_kernel()
+        ip = kishu_ipython()
         user_ns = {} if ip is None else ip.user_ns
         return set(varname for varname, _ in filter(no_ipython_var, user_ns.items()))
 
@@ -392,7 +393,7 @@ class KishuForJupyter:
         """
         Restores a variable state from commit_id.
         """
-        ip = get_jupyter_kernel()
+        ip = kishu_ipython()
         if ip is None:
             raise ValueError("Jupyter kernel is unexpectedly None.")
 
@@ -409,7 +410,7 @@ class KishuForJupyter:
             commit_id = retrieved_branches[0].commit_id
             is_detach = False
 
-        # Retrieve checkout plan
+        # Retrieve checkout plan.
         checkpoint_file = self.checkpoint_file()
         unit_exec_cell = UnitExecution.get_from_db(checkpoint_file, commit_id)
         if unit_exec_cell is None:
@@ -418,9 +419,15 @@ class KishuForJupyter:
         if commit_entry.restore_plan is None:
             raise ValueError("No restore plan found for commit_id = {}".format(commit_id))
 
-        # Restore notebook cells
+        # Restore notebook cells.
         if not skip_notebook and commit_entry.raw_nb is not None:
             self._checkout_notebook(commit_entry.raw_nb)
+
+        # Restore list of executed cells.
+        if commit_entry.executed_cells is not None:
+            current_executed_cells = kishu_ipython_in()
+            if current_executed_cells is not None:
+                current_executed_cells[:] = commit_entry.executed_cells[:]
 
         # Restore user-namespace variables.
         user_ns = ip.user_ns   # will restore to global namespace
@@ -531,6 +538,7 @@ class KishuForJupyter:
 
         # Force saving to observe all cells and extract notebook informations.
         self._save_notebook()
+        entry.executed_cells = kishu_ipython_in()
         entry.raw_nb, entry.formatted_cells = self._all_notebook_cells()
 
         # Plan for checkpointing and restoration.
@@ -558,7 +566,7 @@ class KishuForJupyter:
         TODO: Perform more intelligent checkpointing.
         """
         # Step 1: checkpoint
-        ip = get_jupyter_kernel()
+        ip = kishu_ipython()
         user_ns = {} if ip is None else ip.user_ns
         checkpoint_file = self.checkpoint_file()
         exec_id = cell_info.exec_id
@@ -693,7 +701,8 @@ def repr_if_not_none(obj: Any) -> Optional[str]:
 
 
 IPYTHON_VARS = set(['In', 'Out', 'get_ipython', 'exit', 'quit', 'open'])
-KISHU_VARS = set(['kishu', 'load_kishu'])
+KISHU_INSTRUMENT = '_kishu'
+KISHU_VARS = set(['kishu', 'load_kishu', KISHU_INSTRUMENT])
 
 
 def no_ipython_var(name_obj: Tuple[str, Any]) -> bool:
@@ -720,42 +729,35 @@ def get_epoch_time_ms() -> int:
     return round(time.time() * 1000)
 
 
-# Set when kishu_for_jupyter() is invoked within Jupyter. Interestingly, simply calling
-# get_ipython() does not always access the globally accessible function; thus, we are taking this
-# approach.
-_ipython_shell = None
+# Interestingly, simply calling get_ipython() does not always access the globally accessible
+# function; thus, we are taking this approach.
+_kishu_ipython = None
 
 
-def get_jupyter_kernel():
-    return _ipython_shell
+def kishu_ipython():
+    return _kishu_ipython
 
 
-# The singleton instance for execution history.
-_kishu_exec_history: Optional[KishuForJupyter] = None
-
-
-def get_kishu_instance():
-    return _kishu_exec_history
-
-
-KISHU_VAR_NAME = '_kishu'
+def kishu_ipython_in() -> Optional[List[str]]:
+    ip = kishu_ipython()
+    if ip is None:
+        return None
+    return ip.user_ns["In"]
 
 
 def load_kishu(notebook_id: Optional[str] = None, session_id: Optional[int] = None) -> None:
-    global _kishu_exec_history
-    global _ipython_shell
-    if _kishu_exec_history is not None:
+    global _kishu_ipython
+    if _kishu_ipython is not None:
         return
-    _ipython_shell = eval('get_ipython()')
-    ip = _ipython_shell
-    kishu = None
+    _kishu_ipython = eval('get_ipython()')
+    ip = kishu_ipython()
+
     kishu = KishuForJupyter(notebook_id)
-    _kishu_exec_history = kishu
     if session_id:
         kishu.set_session_id(session_id)
     ip.events.register('pre_run_cell', kishu.pre_run_cell)
     ip.events.register('post_run_cell', kishu.post_run_cell)
-    ip.user_ns[KISHU_VAR_NAME] = kishu
+    ip.user_ns[KISHU_INSTRUMENT] = kishu
 
     print("Kishu will now trace cell executions automatically.\n"
           "- You can inspect traced information using '_kishu'.\n"

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -3,7 +3,7 @@ import pytest
 
 from typing import Generator, List, Optional, Type
 
-from kishu.commands import CommitSummary, KishuCommand, HistoricalCommit, SelectedCommit
+from kishu.commands import CommitSummary, KishuCommand, FECommit, FESelectedCommit
 from kishu.jupyterint import CommitEntryKind, CommitEntry, KishuForJupyter
 from kishu.storage.branch import KishuBranch
 from kishu.storage.commit_graph import CommitNodeInfo
@@ -292,14 +292,19 @@ class TestKishuCommand:
 
     def test_fe_commit(self, notebook_id, basic_execution_ids):
         fe_commit_result = KishuCommand.fe_commit(notebook_id, basic_execution_ids[-1], vardepth=0)
-        assert fe_commit_result == SelectedCommit(
-            commit=HistoricalCommit(
+        assert fe_commit_result == FESelectedCommit(
+            commit=FECommit(
                 oid="0:3",
                 parent_oid="0:2",
                 timestamp=fe_commit_result.commit.timestamp,  # Not tested
                 branches=[],
                 tags=[],
             ),
+            executed_cells=[  # TODO: Missing due to missing IPython kernel.
+                # "x = 1",
+                # "y = 2",
+                # "y = x + 1",
+            ],
             cells=fe_commit_result.cells,  # Not tested
             variables=[],
         )

--- a/kishu/tests/test_jupyterint.py
+++ b/kishu/tests/test_jupyterint.py
@@ -102,6 +102,10 @@ def test_record_history():
             "end_time_ms": 0,
             "exec_id": "0:1",
             "execution_count": 1,
+            'executed_cells': [
+                '',
+                'from kishu import load_kishu\nload_kishu()\n_kishu.set_test_mode()',
+            ],
             "kind": "jupyter",
             "message": "",
             "ahg_string": "",
@@ -113,6 +117,11 @@ def test_record_history():
             "code_block": "a = 1",
             "end_time_ms": 0,
             "exec_id": "0:2",
+            'executed_cells': [
+                '',
+                'from kishu import load_kishu\nload_kishu()\n_kishu.set_test_mode()',
+                'a = 1',
+            ],
             "execution_count": 2,
             "runtime_ms": 0,
             "start_time_ms": 0,


### PR DESCRIPTION
- Reach for `In` variable which keeps track of the executed cells from IPython's point of view
- Store in commit entry
- Restore `In` during checkout

Tested in unit tests and manually