### PR TITLE
List Kishu sessions and join with alive IPython kernels

### DIFF
--- a/kishu/kishu/backend.py
+++ b/kishu/kishu/backend.py
@@ -18,26 +18,34 @@ def health():
     return json.dumps({"status": "ok"})
 
 
-@app.get("/log/<notebook_id>/<commit_id>")
-def log(notebook_id: str, commit_id: str):
+@app.get("/list")
+def list() -> str:
+    list_all: bool = request.args.get('list_all', default=False, type=is_true)
+    list_result = KishuCommand.list(list_all=list_all)
+    return into_json(list_result)
+
+
+@app.get("/log/<notebook_id>")
+def log(notebook_id: str) -> str:
+    commit_id: Optional[str] = request.args.get('commit_id', default=None, type=str)
     log_result = KishuCommand.log(notebook_id, commit_id)
     return into_json(log_result)
 
 
 @app.get("/log_all/<notebook_id>")
-def log_all(notebook_id: str):
+def log_all(notebook_id: str) -> str:
     log_all_result = KishuCommand.log_all(notebook_id)
     return into_json(log_all_result)
 
 
 @app.get("/status/<notebook_id>/<commit_id>")
-def status(notebook_id: str, commit_id: str):
+def status(notebook_id: str, commit_id: str) -> str:
     status_result = KishuCommand.status(notebook_id, commit_id)
     return into_json(status_result)
 
 
 @app.get("/checkout/<notebook_id>/<branch_or_commit_id>")
-def checkout(notebook_id: str, branch_or_commit_id: str):
+def checkout(notebook_id: str, branch_or_commit_id: str) -> str:
     skip_notebook: bool = request.args.get('skip_notebook', default=False, type=is_true)
     checkout_result = KishuCommand.checkout(
         notebook_id,
@@ -48,7 +56,7 @@ def checkout(notebook_id: str, branch_or_commit_id: str):
 
 
 @app.get("/branch/<notebook_id>/<branch_name>")
-def branch(notebook_id: str, branch_name: str):
+def branch(notebook_id: str, branch_name: str) -> str:
     commit_id: Optional[str] = request.args.get('commit_id', default=None, type=str)
     do_commit: bool = request.args.get('do_commit', default=False, type=is_true)
     branch_result = KishuCommand.branch(notebook_id, branch_name, commit_id, do_commit=do_commit)
@@ -56,7 +64,7 @@ def branch(notebook_id: str, branch_name: str):
 
 
 @app.get("/tag/<notebook_id>/<tag_name>")
-def tag(notebook_id: str, tag_name: str):
+def tag(notebook_id: str, tag_name: str) -> str:
     commit_id: Optional[str] = request.args.get('commit_id', default=None, type=str)
     message: str = request.args.get('message', default="", type=str)
     tag_result = KishuCommand.tag(notebook_id, tag_name, commit_id, message)
@@ -64,7 +72,7 @@ def tag(notebook_id: str, tag_name: str):
 
 
 @app.get("/fe/commit_graph/<notebook_id>")
-def fe_commit_graph(notebook_id: str):
+def fe_commit_graph(notebook_id: str) -> str:
     fe_commit_graph_result = KishuCommand.fe_commit_graph(notebook_id)
     return into_json(fe_commit_graph_result)
 

--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -39,6 +39,21 @@ Kishu Commands.
 
 
 @kishu_app.command()
+def list(
+    list_all: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="List all Kishu sessions.",
+    ),
+) -> None:
+    """
+    List existing Kishu sessions.
+    """
+    print(into_json(KishuCommand.list(list_all=list_all)))
+
+
+@kishu_app.command()
 def log(
     notebook_id: str = typer.Argument(
         ...,

--- a/kishu/kishu/storage/path.py
+++ b/kishu/kishu/storage/path.py
@@ -1,9 +1,14 @@
 import os
 import pathlib
 
+from typing import Generator
+
+
+ENV_KISHU_PATH_ROOT = "KISHU_PATH_ROOT"
+
 
 class KishuPath:
-    ROOT = pathlib.Path.home()
+    ROOT = os.environ.get(ENV_KISHU_PATH_ROOT, None) or str(pathlib.Path.home())
 
     @staticmethod
     def kishu_directory() -> str:
@@ -37,6 +42,14 @@ class KishuPath:
     @staticmethod
     def head_path(notebook_id: str) -> str:
         return os.path.join(KishuPath.notebook_directory(notebook_id), "head.json")
+
+    @staticmethod
+    def iter_notebook_ids() -> Generator[str, None, None]:
+        kishu_dir = KishuPath.kishu_directory()
+        for notebook_id in os.listdir(KishuPath.kishu_directory()):
+            if not os.path.isdir(os.path.join(kishu_dir, notebook_id)):
+                continue
+            yield notebook_id
 
     @staticmethod
     def _create_dir(dir: str) -> str:

--- a/kishu/requirements.txt
+++ b/kishu/requirements.txt
@@ -10,6 +10,7 @@ jupyter_ui_poll
 nbconvert
 nbformat
 networkx
+psutil
 typing
 
 # User interfaces: cli, backend, jupyterlab_kishu

--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+
+from pathlib import Path
+from typing import Generator, Type
+
+from kishu.backend import app as kishu_app
+from kishu.storage.path import ENV_KISHU_PATH_ROOT, KishuPath
+
+
+# Use this fixture to mount Kishu in a temporary directory in the same process.
+@pytest.fixture()
+def tmp_kishu_path(tmp_path: Path) -> Generator[Type[KishuPath], None, None]:
+    original_root = KishuPath.ROOT
+    KishuPath.ROOT = str(tmp_path)
+    yield KishuPath
+    KishuPath.ROOT = original_root
+
+
+# Use this fixture to mount Kishu in a temporary directory across processes.
+@pytest.fixture()
+def tmp_kishu_path_os(tmp_path: Path) -> Generator[Type[KishuPath], None, None]:
+    original_root = os.environ.get(ENV_KISHU_PATH_ROOT, None)
+    os.environ[ENV_KISHU_PATH_ROOT] = str(tmp_path)
+    yield KishuPath
+    if original_root is not None:
+        os.environ[ENV_KISHU_PATH_ROOT] = original_root
+
+
+@pytest.fixture()
+def backend_client():
+    return kishu_app.test_client()

--- a/kishu/tests/test_backend.py
+++ b/kishu/tests/test_backend.py
@@ -1,0 +1,27 @@
+import json
+from kishu.commands import (
+    ListResult,
+    LogResult,
+)
+
+
+def test_health(backend_client):
+    result = backend_client.get("/health")
+    data = json.loads(result.data)
+    assert data["status"] == "ok"
+
+
+def test_list_empty(backend_client, tmp_kishu_path):
+    result = backend_client.get("/list")
+    assert result.status_code == 200
+    assert ListResult.from_json(result.data) == ListResult(sessions=[])
+
+    result = backend_client.get("/list?list_all=true")
+    assert result.status_code == 200
+    assert ListResult.from_json(result.data) == ListResult(sessions=[])
+
+
+def test_log_empty(backend_client, tmp_kishu_path):
+    result = backend_client.get("/log/NON_EXISTENT_NOTEBOOK_ID")
+    assert result.status_code == 200
+    assert LogResult.from_json(result.data) == LogResult(commit_graph=[])

--- a/kishu/tests/test_cli.py
+++ b/kishu/tests/test_cli.py
@@ -5,6 +5,10 @@ from typing import Generator
 
 from kishu import __app_name__, __version__
 from kishu.cli import kishu_app
+from kishu.commands import (
+    ListResult,
+    LogResult,
+)
 
 
 @pytest.fixture()
@@ -23,3 +27,21 @@ class TestKishuApp:
         result = runner.invoke(kishu_app, ["-v"])
         assert result.exit_code == 0
         assert f"{__app_name__} v{__version__}\n" in result.stdout
+
+    def test_list_empty(self, runner, tmp_kishu_path):
+        result = runner.invoke(kishu_app, ["list"])
+        assert result.exit_code == 0
+        assert ListResult.from_json(result.stdout) == ListResult(sessions=[])
+
+        result = runner.invoke(kishu_app, ["list", "-a"])
+        assert result.exit_code == 0
+        assert ListResult.from_json(result.stdout) == ListResult(sessions=[])
+
+        result = runner.invoke(kishu_app, ["list", "--all"])
+        assert result.exit_code == 0
+        assert ListResult.from_json(result.stdout) == ListResult(sessions=[])
+
+    def test_log_empty(self, runner, tmp_kishu_path):
+        result = runner.invoke(kishu_app, ["log", "NON_EXISTENT_NOTEBOOK_ID"])
+        assert result.exit_code == 0
+        assert LogResult.from_json(result.stdout) == LogResult(commit_graph=[])


### PR DESCRIPTION
- Useful for listing both currently alive and disconnected Kishu sessions
- List from Kishu directory
- Join with IPython kernels
  - Refactor discovery code
- Fix test to move Kishu directory into temporary location (to avoid cluttering actual Kishu)

Tested in unit tests and manually