### PR TITLE
Init Kishu on a notebook through CLI/backend

### DIFF
--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -54,6 +54,20 @@ def list(
 
 
 @kishu_app.command()
+def init(
+    notebook_path: str = typer.Argument(
+        ...,
+        help="Path to the notebook to initialize Kishu on.",
+        show_default=False
+    ),
+) -> None:
+    """
+    Initialize Kishu instrumentation in a notebook.
+    """
+    print(into_json(KishuCommand.init(notebook_path)))
+
+
+@kishu_app.command()
 def log(
     notebook_id: str = typer.Argument(
         ...,

--- a/kishu/kishu/runtime.py
+++ b/kishu/kishu/runtime.py
@@ -54,17 +54,6 @@ def _iter_maybe_sessions() -> Generator[Tuple[dict, dict], None, None]:
 
 class JupyterRuntimeEnv:
     @staticmethod
-    def notebook_path_from_kernel(kernel_id: str) -> Path:
-        if os.environ.get("notebook_path"):
-            path_str = os.environ.get("notebook_path")
-            assert path_str is not None
-            return Path(path_str)
-        for sess in JupyterRuntimeEnv.iter_sessions():
-            if sess.kernel_id == kernel_id:
-                return sess.notebook_path
-        raise FileNotFoundError("Failed to identify notebook file path.")
-
-    @staticmethod
     def enclosing_kernel_id() -> str:
         # TODO needs to be called inside ipython kernel
         if os.environ.get("notebook_path"):  # means we are testing
@@ -85,3 +74,21 @@ class JupyterRuntimeEnv:
                 kernel_id=sess["kernel"]["id"],
                 notebook_path=Path(srv.get("root_dir") or srv["notebook_dir"]) / relative_path
             )
+
+    @staticmethod
+    def notebook_path_from_kernel(kernel_id: str) -> Path:
+        if os.environ.get("notebook_path"):
+            path_str = os.environ.get("notebook_path")
+            assert path_str is not None
+            return Path(path_str)
+        for sess in JupyterRuntimeEnv.iter_sessions():
+            if sess.kernel_id == kernel_id:
+                return sess.notebook_path
+        raise FileNotFoundError("Failed to identify notebook file path.")
+
+    @staticmethod
+    def kernel_id_from_notebook(notebook_path: Path) -> str:
+        for sess in JupyterRuntimeEnv.iter_sessions():
+            if sess.notebook_path.resolve() == notebook_path.resolve():
+                return sess.kernel_id
+        raise FileNotFoundError("Kernel for the notebook not found.")

--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -3,13 +3,18 @@ import os
 import pytest
 import shutil
 
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Generator, Type
 from unittest.mock import patch
 
 from kishu.backend import app as kishu_app
 from kishu.storage.path import ENV_KISHU_PATH_ROOT, KishuPath
 from tests.helpers.nbexec import NB_DIR
+
+
+"""
+Kishu Resources
+"""
 
 
 # Use this fixture to mount Kishu in a temporary directory in the same process.
@@ -36,20 +41,46 @@ def backend_client():
     return kishu_app.test_client()
 
 
-# Dummy server with dummy data
-MOCK_SERVER = {
-        'url': 'http://localhost:8888/',
-        'token': 'token_value',
-        'pid': 12345,
-        'root_dir': '/root/',
-        'notebook_dir': '/notebooks/'
-    }
+"""
+Test Resources: notebooks, test cases, data
+"""
 
-# Dummy session with dummy data
+
+@pytest.fixture()
+def kishu_test_dir() -> Path:
+    return Path(__file__).resolve().parents[0]
+
+
+KISHU_TEST_NOTEBOOKS_DIR = "notebooks"
+
+
+@pytest.fixture()
+def nb_simple_path(tmp_path: Path, kishu_test_dir: Path) -> Path:
+    real_nb_path = kishu_test_dir / PurePath(KISHU_TEST_NOTEBOOKS_DIR, "simple.ipynb")
+    tmp_nb_path = tmp_path / PurePath("simple.ipynb")
+    shutil.copy(real_nb_path, tmp_nb_path)
+    return tmp_nb_path
+
+
+"""
+Jupyter runtime mocks
+"""
+
+
+# Mock Jupyter server info.
+MOCK_SERVER = {
+    'url': 'http://localhost:8888/',
+    'token': 'token_value',
+    'pid': 12345,
+    'root_dir': '/root/',
+    'notebook_dir': '/notebooks/'
+}
+
+# Mock Jupyter session info.
 MOCK_SESSION = {
-        'notebook': {'path': 'notebook1.ipynb'},
-        'kernel': {'id': 'kernel_id_1'}
-    }
+    'notebook': {'path': 'notebook1.ipynb'},
+    'kernel': {'id': 'kernel_id_1'}
+}
 
 
 # Ensures Path.glob() returns the notebook path we want to return

--- a/kishu/tests/test_cli.py
+++ b/kishu/tests/test_cli.py
@@ -7,6 +7,7 @@ from kishu import __app_name__, __version__
 from kishu.cli import kishu_app
 from kishu.commands import (
     ListResult,
+    InitResult,
     LogResult,
 )
 
@@ -40,6 +41,26 @@ class TestKishuApp:
         result = runner.invoke(kishu_app, ["list", "--all"])
         assert result.exit_code == 0
         assert ListResult.from_json(result.stdout) == ListResult(sessions=[])
+
+    def test_init_empty(self, runner, tmp_kishu_path):
+        result = runner.invoke(kishu_app, ["init", "non_existent_notebook.ipynb"])
+        assert result.exit_code == 0
+        init_result = InitResult.from_json(result.stdout)
+        assert init_result == InitResult(
+            status="error",
+            message="FileNotFoundError: Kernel for the notebook not found.",
+        )
+
+    def test_init_simple(self, runner, tmp_kishu_path, nb_simple_path):
+        result = runner.invoke(kishu_app, ["init", str(nb_simple_path)])
+        assert result.exit_code == 0
+
+        # TODO: This should pass with Jupyter Server
+        init_result = InitResult.from_json(result.stdout)
+        assert init_result == InitResult(
+            status="error",
+            message="FileNotFoundError: Kernel for the notebook not found.",
+        )
 
     def test_log_empty(self, runner, tmp_kishu_path):
         result = runner.invoke(kishu_app, ["log", "NON_EXISTENT_NOTEBOOK_ID"])

--- a/kishu/tests/test_runtime.py
+++ b/kishu/tests/test_runtime.py
@@ -34,6 +34,11 @@ def test_session_with_root_dir(mock_servers):
     assert sessions == [expected_session]
 
 
+def test_kernel_id_from_notebook(mock_servers):
+    kernel_id = JupyterRuntimeEnv.kernel_id_from_notebook(Path("/root/notebook1.ipynb"))
+    assert kernel_id == "kernel_id_1"
+
+
 def test_iter_maybe_running_servers_bad_json():
     with patch('kishu.runtime.json.loads', side_effect=json.JSONDecodeError("", "", 0)):
         result = list(_iter_maybe_running_servers())


### PR DESCRIPTION
- Extend `JupyterConnection` interface to take preprocessing command + works from kernel ID
- Implement `kishu init` when kernel is alive
- Connect to CLI and backend

Tested in unit tests