### PR TITLE
Parse notebook ID as a notebook path or a key on CLI

### DIFF
--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 from kishu import __app_name__, __version__
 from kishu.commands import KishuCommand, into_json
+from kishu.notebook_id import NotebookId
 
 
 kishu_app = typer.Typer(add_completion=False)
@@ -69,8 +70,9 @@ def init(
 
 @kishu_app.command()
 def log(
-    notebook_id: str = typer.Argument(
+    notebook_key: str = typer.Argument(
         ...,
+        parser=NotebookId.parse_key_from_path_or_key,
         help="Notebook ID to interact with.",
         show_default=False
     ),
@@ -90,15 +92,16 @@ def log(
     Show a history view of commit graph.
     """
     if log_all:
-        print(into_json(KishuCommand.log_all(notebook_id)))
+        print(into_json(KishuCommand.log_all(notebook_key)))
     else:
-        print(into_json(KishuCommand.log(notebook_id, commit_id)))
+        print(into_json(KishuCommand.log(notebook_key, commit_id)))
 
 
 @kishu_app.command()
 def status(
-    notebook_id: str = typer.Argument(
+    notebook_key: str = typer.Argument(
         ...,
+        parser=NotebookId.parse_key_from_path_or_key,
         help="Notebook ID to interact with.",
         show_default=False
     ),
@@ -107,13 +110,14 @@ def status(
     """
     Show a commit in detail.
     """
-    print(into_json(KishuCommand.status(notebook_id, commit_id)))
+    print(into_json(KishuCommand.status(notebook_key, commit_id)))
 
 
 @kishu_app.command()
 def commit(
-    notebook_id: str = typer.Argument(
+    notebook_key: str = typer.Argument(
         ...,
+        parser=NotebookId.parse_key_from_path_or_key,
         help="Notebook ID to interact with.",
         show_default=False
     ),
@@ -128,13 +132,14 @@ def commit(
     """
     Checkout a notebook to a commit.
     """
-    print(into_json(KishuCommand.commit(notebook_id, message=message)))
+    print(into_json(KishuCommand.commit(notebook_key, message=message)))
 
 
 @kishu_app.command()
 def checkout(
-    notebook_id: str = typer.Argument(
+    notebook_key: str = typer.Argument(
         ...,
+        parser=NotebookId.parse_key_from_path_or_key,
         help="Notebook ID to interact with.",
         show_default=False
     ),
@@ -154,7 +159,7 @@ def checkout(
     Checkout a notebook to a commit.
     """
     print(into_json(KishuCommand.checkout(
-        notebook_id,
+        notebook_key,
         branch_or_commit_id,
         skip_notebook=skip_notebook,
     )))
@@ -162,8 +167,9 @@ def checkout(
 
 @kishu_app.command()
 def branch(
-    notebook_id: str = typer.Argument(
+    notebook_key: str = typer.Argument(
         ...,
+        parser=NotebookId.parse_key_from_path_or_key,
         help="Notebook ID to interact with.",
         show_default=False
     ),
@@ -193,12 +199,12 @@ def branch(
     Create, rename, or delete branches.
     """
     if create_branch_name is not None:
-        print(into_json(KishuCommand.branch(notebook_id, create_branch_name, commit_id)))
+        print(into_json(KishuCommand.branch(notebook_key, create_branch_name, commit_id)))
     if rename_branch != (None, None):
         old_name, new_name = rename_branch
         try:
             print(into_json(KishuCommand.rename_branch(
-                notebook_id, old_name, new_name)))
+                notebook_key, old_name, new_name)))
         except Exception as error:
             # Old_name does not exist and/or new_name already exists
             typer.echo(f"Error: {str(error)}", err=True)
@@ -207,8 +213,9 @@ def branch(
 
 @kishu_app.command()
 def tag(
-    notebook_id: str = typer.Argument(
+    notebook_key: str = typer.Argument(
         ...,
+        parser=NotebookId.parse_key_from_path_or_key,
         help="Notebook ID to interact with.",
         show_default=False
     ),
@@ -231,7 +238,7 @@ def tag(
     """
     Create or edit tags.
     """
-    print(into_json(KishuCommand.tag(notebook_id, tag_name, commit_id, message)))
+    print(into_json(KishuCommand.tag(notebook_key, tag_name, commit_id, message)))
 
 
 """
@@ -244,8 +251,9 @@ kishu_experimental_app = typer.Typer(add_completion=False)
 
 @kishu_experimental_app.command()
 def fegraph(
-    notebook_id: str = typer.Argument(
+    notebook_key: str = typer.Argument(
         ...,
+        parser=NotebookId.parse_key_from_path_or_key,
         help="Notebook ID to interact with.",
         show_default=False
     ),
@@ -253,13 +261,14 @@ def fegraph(
     """
     Show the frontend commit graph.
     """
-    print(into_json(KishuCommand.fe_commit_graph(notebook_id)))
+    print(into_json(KishuCommand.fe_commit_graph(notebook_key)))
 
 
 @kishu_experimental_app.command()
 def fecommit(
-    notebook_id: str = typer.Argument(
+    notebook_key: str = typer.Argument(
         ...,
+        parser=NotebookId.parse_key_from_path_or_key,
         help="Notebook ID to interact with.",
         show_default=False
     ),
@@ -273,7 +282,7 @@ def fecommit(
     """
     Show the commit in frontend detail.
     """
-    print(into_json(KishuCommand.fe_commit(notebook_id, commit_id, vardepth)))
+    print(into_json(KishuCommand.fe_commit(notebook_key, commit_id, vardepth)))
 
 
 if os.environ.get("KISHU_ENABLE_EXPERIMENTAL", "false").lower() in ('true', '1', 't'):

--- a/kishu/kishu/commands.py
+++ b/kishu/kishu/commands.py
@@ -176,7 +176,7 @@ class KishuCommand:
             sessions = list(filter(lambda session: session.is_alive, sessions))
 
         # Sort by notebook ID.
-        sessions = sorted(sessions, key=lambda session: session.notebook_id)
+        sessions = sorted(sessions, key=lambda session: session.notebook_key)
         return ListResult(sessions=sessions)
 
     @staticmethod

--- a/kishu/kishu/exceptions.py
+++ b/kishu/kishu/exceptions.py
@@ -9,6 +9,21 @@ class TypeNotSupportedError(Exception):
 
 
 """
+Raised by notebook_id
+"""
+
+
+class MissingNotebookMetadataError(Exception):
+    def __init__(self):
+        super().__init__("Missing Kishu metadata in the notebook.")
+
+
+class NotNotebookPathOrKey(Exception):
+    def __init__(self, s: str):
+        super().__init__(f"\"{s}\" is neither a notebook path nor a Kishu notebook key.")
+
+
+"""
 Raised by jupyterint
 """
 

--- a/kishu/kishu/notebook_id.py
+++ b/kishu/kishu/notebook_id.py
@@ -1,8 +1,32 @@
 from __future__ import annotations
 
+import json
+import nbformat
+from dataclasses import dataclass, asdict
+from dataclasses_json import dataclass_json
+from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
+from kishu.exceptions import (
+    MissingNotebookMetadataError,
+    NotNotebookPathOrKey,
+)
 from kishu.runtime import JupyterRuntimeEnv
+from kishu.storage.path import KishuPath
+
+
+@dataclass
+class KishuNotebookMetadata:
+    notebook_id: str
+    session_count: int = 0
+
+
+@dataclass_json
+@dataclass
+class JupyterConnectionInfo:
+    kernel_id: str
+    notebook_path: str
 
 
 class NotebookId:
@@ -20,6 +44,22 @@ class NotebookId:
         path = JupyterRuntimeEnv.notebook_path_from_kernel(kernel_id)
         return NotebookId(key=key, path=path, kernel_id=kernel_id)
 
+    @staticmethod
+    def parse_key_from_path_or_key(path_or_key: str) -> str:
+        # Try parsing as path, if exists.
+        path = Path(path_or_key)
+        if path.exists():
+            nb = JupyterRuntimeEnv.read_notebook(path)
+            metadata = NotebookId.read_kishu_metadata(nb)
+            return metadata.notebook_id
+
+        # Notebook path does not exist, try parsing as key.
+        key = path_or_key
+        if KishuPath.exists(key):
+            return key
+
+        raise NotNotebookPathOrKey(path_or_key)
+
     def key(self) -> str:
         return self._key
 
@@ -29,5 +69,45 @@ class NotebookId:
     def kernel_id(self) -> str:
         return self._kernel_id
 
-    def set_key(self, new_key: str) -> None:
-        self._key = new_key
+    """
+    Kishu notebook metadata.
+    """
+
+    @staticmethod
+    def write_kishu_metadata(nb: nbformat.NotebookNode) -> KishuNotebookMetadata:
+        if "kishu" not in nb.metadata:
+            # Create new Kishu metadata.
+            notebook_name = datetime.now().strftime('%Y%m%dT%H%M%S')
+            metadata = KishuNotebookMetadata(notebook_name)
+        else:
+            # Read existing Kishu metadata
+            metadata = KishuNotebookMetadata(**nb.metadata.kishu)
+        metadata.session_count += 1
+        nb["metadata"]["kishu"] = asdict(metadata)
+        return metadata
+
+    @staticmethod
+    def read_kishu_metadata(nb: nbformat.NotebookNode) -> KishuNotebookMetadata:
+        if "kishu" not in nb.metadata:
+            raise MissingNotebookMetadataError()
+        return KishuNotebookMetadata(**nb.metadata.kishu)
+
+    """
+    Kishu Jupyter connection information.
+    """
+
+    def record_connection(self) -> None:
+        with open(KishuPath.connection_path(self._key), 'w') as f:
+            f.write(JupyterConnectionInfo(  # type: ignore
+                kernel_id=self._kernel_id,
+                notebook_path=str(self._path),
+            ).to_json())
+
+    @staticmethod
+    def try_retrieve_connection(key: str) -> Optional[JupyterConnectionInfo]:
+        try:
+            with open(KishuPath.connection_path(key), 'r') as f:
+                json_str = f.read()
+                return JupyterConnectionInfo.from_json(json_str)  # type: ignore
+        except (FileNotFoundError, json.decoder.JSONDecodeError):
+            return None

--- a/kishu/kishu/storage/path.py
+++ b/kishu/kishu/storage/path.py
@@ -18,38 +18,42 @@ class KishuPath:
         return KishuPath._create_dir(os.path.join(KishuPath.ROOT, ".kishu"))
 
     @staticmethod
-    def notebook_directory(notebook_id: str) -> str:
+    def notebook_directory(notebook_key: str) -> str:
         """
         Creates a directory kishu will use for checkpointing a notebook. Creates if none exists.
         """
-        return KishuPath._create_dir(os.path.join(KishuPath.kishu_directory(), notebook_id))
+        return KishuPath._create_dir(os.path.join(KishuPath.kishu_directory(), notebook_key))
 
     @staticmethod
-    def checkpoint_path(notebook_id: str) -> str:
-        return os.path.join(KishuPath.notebook_directory(notebook_id), "ckpt.sqlite")
+    def checkpoint_path(notebook_key: str) -> str:
+        return os.path.join(KishuPath.notebook_directory(notebook_key), "ckpt.sqlite")
 
     @staticmethod
-    def commit_graph_directory(notebook_id: str) -> str:
+    def commit_graph_directory(notebook_key: str) -> str:
         return KishuPath._create_dir(os.path.join(
-            KishuPath.notebook_directory(notebook_id),
+            KishuPath.notebook_directory(notebook_key),
             "commit_graph")
         )
 
     @staticmethod
-    def connection_path(notebook_id: str) -> str:
-        return os.path.join(KishuPath.notebook_directory(notebook_id), "connection.json")
+    def connection_path(notebook_key: str) -> str:
+        return os.path.join(KishuPath.notebook_directory(notebook_key), "connection.json")
 
     @staticmethod
-    def head_path(notebook_id: str) -> str:
-        return os.path.join(KishuPath.notebook_directory(notebook_id), "head.json")
+    def head_path(notebook_key: str) -> str:
+        return os.path.join(KishuPath.notebook_directory(notebook_key), "head.json")
 
     @staticmethod
-    def iter_notebook_ids() -> Generator[str, None, None]:
+    def exists(notebook_key: str) -> bool:
+        return os.path.exists(os.path.join(KishuPath.kishu_directory(), notebook_key))
+
+    @staticmethod
+    def iter_notebook_keys() -> Generator[str, None, None]:
         kishu_dir = KishuPath.kishu_directory()
-        for notebook_id in os.listdir(KishuPath.kishu_directory()):
-            if not os.path.isdir(os.path.join(kishu_dir, notebook_id)):
+        for notebook_key in os.listdir(KishuPath.kishu_directory()):
+            if not os.path.isdir(os.path.join(kishu_dir, notebook_key)):
                 continue
-            yield notebook_id
+            yield notebook_key
 
     @staticmethod
     def _create_dir(dir: str) -> str:

--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -79,7 +79,7 @@ MOCK_SERVER = {
 # Mock Jupyter session info.
 MOCK_SESSION = {
     'notebook': {'path': 'notebook1.ipynb'},
-    'kernel': {'id': 'kernel_id_1'}
+    'kernel': {'id': 'test_kernel_id'}
 }
 
 
@@ -110,7 +110,7 @@ def create_temporary_copy(path: str, filename: str, temp_dir: str):
     return temp_path
 
 
-# Sets notebook_path environment variable to be the path to a temporary copy of a notebook
+# Sets TEST_NOTEBOOK_PATH environment variable to be the path to a temporary copy of a notebook
 @pytest.fixture
 def set_notebook_path_env(tmp_path, request):
     notebook_name = getattr(request, "param", "simple.ipynb")
@@ -118,8 +118,8 @@ def set_notebook_path_env(tmp_path, request):
     notebook_full_path = os.path.join(path_to_notebook, NB_DIR, notebook_name)
     temp_path = create_temporary_copy(notebook_full_path, notebook_name, tmp_path)
 
-    os.environ['notebook_path'] = temp_path
+    os.environ["TEST_NOTEBOOK_PATH"] = temp_path
 
     yield temp_path
 
-    del os.environ['notebook_path']
+    del os.environ["TEST_NOTEBOOK_PATH"]

--- a/kishu/tests/notebooks/simple_with_kishu.ipynb
+++ b/kishu/tests/notebooks/simple_with_kishu.ipynb
@@ -1,0 +1,132 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "y = x\n",
+    "x = x + 1\n",
+    "z = 1\n",
+    "a = 1\n",
+    "del a\n",
+    "a = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Record imported libraries\n",
+    "import numpy as np\n",
+    "from numpy import random"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "b = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def func():\n",
+    "    global b\n",
+    "    b += 1\n",
+    "func()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "kishu": {
+   "notebook_id": "simple_kishu_notebook_key",
+   "session_count": 1
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "831878006862ccc20c8644a68163e333be809b5fee14b33e0a32c4838e696fe8"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/kishu/tests/test_cli.py
+++ b/kishu/tests/test_cli.py
@@ -4,17 +4,19 @@ from typer.testing import CliRunner
 from typing import Generator
 
 from kishu import __app_name__, __version__
+from kishu.exceptions import (
+    NotNotebookPathOrKey,
+)
 from kishu.cli import kishu_app
 from kishu.commands import (
     ListResult,
     InitResult,
-    LogResult,
 )
 
 
 @pytest.fixture()
 def runner() -> Generator[CliRunner, None, None]:
-    yield CliRunner()
+    yield CliRunner(mix_stderr=False)
 
 
 class TestKishuApp:
@@ -64,5 +66,6 @@ class TestKishuApp:
 
     def test_log_empty(self, runner, tmp_kishu_path):
         result = runner.invoke(kishu_app, ["log", "NON_EXISTENT_NOTEBOOK_ID"])
-        assert result.exit_code == 0
-        assert LogResult.from_json(result.stdout) == LogResult(commit_graph=[])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, NotNotebookPathOrKey)
+        assert "NON_EXISTENT_NOTEBOOK_ID" in str(result.exception)

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -12,13 +12,13 @@ from kishu.storage.commit_graph import CommitNodeInfo
 
 
 @pytest.fixture()
-def notebook_id() -> Generator[str, None, None]:
+def notebook_key() -> Generator[str, None, None]:
     yield "notebook_123"
 
 
 @pytest.fixture()
-def kishu_jupyter(tmp_kishu_path, notebook_id, set_notebook_path_env) -> Generator[KishuForJupyter, None, None]:
-    kishu_jupyter = KishuForJupyter(notebook_id=NotebookId.from_enclosing_with_key(notebook_id))
+def kishu_jupyter(tmp_kishu_path, notebook_key, set_notebook_path_env) -> Generator[KishuForJupyter, None, None]:
+    kishu_jupyter = KishuForJupyter(notebook_id=NotebookId.from_enclosing_with_key(notebook_key))
     kishu_jupyter.set_test_mode()
     yield kishu_jupyter
 
@@ -56,7 +56,7 @@ class JupyterResultMock:
 
 
 class TestKishuCommand:
-    def test_list(self, set_notebook_path_env, notebook_id, basic_execution_ids):
+    def test_list(self, set_notebook_path_env, notebook_key, basic_execution_ids):
         list_result = KishuCommand.list()
         assert len(list_result.sessions) == 0
 
@@ -64,14 +64,14 @@ class TestKishuCommand:
         list_result = KishuCommand.list(list_all=True)
         assert len(list_result.sessions) == 1
         assert list_result.sessions[0] == KishuSession(
-            notebook_id=notebook_id,
-            kernel_id="dummy_kernel_id",
-            notebook_path=os.environ.get("notebook_path"),
+            notebook_key=notebook_key,
+            kernel_id="test_kernel_id",
+            notebook_path=os.environ.get("TEST_NOTEBOOK_PATH"),
             is_alive=False,
         )
 
-    def test_log(self, notebook_id, basic_execution_ids):
-        log_result = KishuCommand.log(notebook_id, basic_execution_ids[-1])
+    def test_log(self, notebook_key, basic_execution_ids):
+        log_result = KishuCommand.log(notebook_key, basic_execution_ids[-1])
         assert len(log_result.commit_graph) == 3
         assert log_result.commit_graph[0] == CommitSummary(
             commit_id="0:1",
@@ -104,7 +104,7 @@ class TestKishuCommand:
             tags=[],
         )
 
-        log_result = KishuCommand.log(notebook_id, basic_execution_ids[0])
+        log_result = KishuCommand.log(notebook_key, basic_execution_ids[0])
         assert len(log_result.commit_graph) == 1
         assert log_result.commit_graph[0] == CommitSummary(
             commit_id="0:1",
@@ -117,8 +117,8 @@ class TestKishuCommand:
             tags=[],
         )
 
-    def test_log_all(self, notebook_id, basic_execution_ids):
-        log_all_result = KishuCommand.log_all(notebook_id)
+    def test_log_all(self, notebook_key, basic_execution_ids):
+        log_all_result = KishuCommand.log_all(notebook_key)
         assert len(log_all_result.commit_graph) == 3
         assert log_all_result.commit_graph[0] == CommitSummary(
             commit_id="0:1",
@@ -151,8 +151,8 @@ class TestKishuCommand:
             tags=[],
         )
 
-    def test_status(self, notebook_id, basic_execution_ids):
-        status_result = KishuCommand.status(notebook_id, basic_execution_ids[-1])
+    def test_status(self, notebook_key, basic_execution_ids):
+        status_result = KishuCommand.status(notebook_key, basic_execution_ids[-1])
         assert status_result.commit_node_info == CommitNodeInfo(
             commit_id="0:3",
             parent_id="0:2",
@@ -177,17 +177,17 @@ class TestKishuCommand:
             restore_plan=status_result.commit_entry.restore_plan,  # Not tested
         )
 
-    def test_branch(self, notebook_id, basic_execution_ids):
-        branch_result = KishuCommand.branch(notebook_id, "at_head", None)
+    def test_branch(self, notebook_key, basic_execution_ids):
+        branch_result = KishuCommand.branch(notebook_key, "at_head", None)
         assert branch_result.status == "ok"
 
-        branch_result = KishuCommand.branch(notebook_id, "historical", basic_execution_ids[1])
+        branch_result = KishuCommand.branch(notebook_key, "historical", basic_execution_ids[1])
         assert branch_result.status == "ok"
 
-    def test_branch_log(self, notebook_id, basic_execution_ids):
-        _ = KishuCommand.branch(notebook_id, "at_head", None)
-        _ = KishuCommand.branch(notebook_id, "historical", basic_execution_ids[1])
-        log_result = KishuCommand.log(notebook_id, basic_execution_ids[-1])
+    def test_branch_log(self, notebook_key, basic_execution_ids):
+        _ = KishuCommand.branch(notebook_key, "at_head", None)
+        _ = KishuCommand.branch(notebook_key, "historical", basic_execution_ids[1])
+        log_result = KishuCommand.log(notebook_key, basic_execution_ids[-1])
         assert len(log_result.commit_graph) == 3
         assert log_result.commit_graph[0] == CommitSummary(
             commit_id="0:1",
@@ -220,48 +220,48 @@ class TestKishuCommand:
             tags=[],
         )
 
-    def test_rename_branch_basic(self, notebook_id, basic_execution_ids):
+    def test_rename_branch_basic(self, notebook_key, basic_execution_ids):
         branch_1 = "branch_1"
-        KishuCommand.branch(notebook_id, branch_1, None)
+        KishuCommand.branch(notebook_key, branch_1, None)
 
         rename_branch_result = KishuCommand.rename_branch(
-            notebook_id, branch_1, "new_branch")
-        head = KishuBranch.get_head(notebook_id)
+            notebook_key, branch_1, "new_branch")
+        head = KishuBranch.get_head(notebook_key)
         assert rename_branch_result.status == "ok"
         assert head.branch_name == "new_branch"
 
     def test_rename_branch_non_existing_branch(
-            self, notebook_id, basic_execution_ids):
+            self, notebook_key, basic_execution_ids):
         rename_branch_result = KishuCommand.rename_branch(
-            notebook_id, "non_existing_branch", "new_branch")
+            notebook_key, "non_existing_branch", "new_branch")
         assert rename_branch_result.status == "error"
 
     def test_rename_branch_new_repeating_branch(
-            self, notebook_id, basic_execution_ids):
+            self, notebook_key, basic_execution_ids):
         branch_1 = "branch_1"
-        KishuCommand.branch(notebook_id, branch_1, None)
+        KishuCommand.branch(notebook_key, branch_1, None)
 
         rename_branch_result = KishuCommand.rename_branch(
-            notebook_id, branch_1, branch_1)
+            notebook_key, branch_1, branch_1)
         assert rename_branch_result.status == "error"
 
-    def test_tag(self, notebook_id, basic_execution_ids):
-        tag_result = KishuCommand.tag(notebook_id, "at_head", None, "In current time")
+    def test_tag(self, notebook_key, basic_execution_ids):
+        tag_result = KishuCommand.tag(notebook_key, "at_head", None, "In current time")
         assert tag_result.status == "ok"
         assert tag_result.tag_name == "at_head"
         assert tag_result.commit_id == basic_execution_ids[-1]
         assert tag_result.message == "In current time"
 
-        tag_result = KishuCommand.tag(notebook_id, "historical", basic_execution_ids[1], "")
+        tag_result = KishuCommand.tag(notebook_key, "historical", basic_execution_ids[1], "")
         assert tag_result.status == "ok"
         assert tag_result.tag_name == "historical"
         assert tag_result.commit_id == basic_execution_ids[1]
         assert tag_result.message == ""
 
-    def test_tag_log(self, notebook_id, basic_execution_ids):
-        _ = KishuCommand.tag(notebook_id, "at_head", None, "In current time")
-        _ = KishuCommand.tag(notebook_id, "historical", basic_execution_ids[1], "")
-        log_result = KishuCommand.log(notebook_id, basic_execution_ids[-1])
+    def test_tag_log(self, notebook_key, basic_execution_ids):
+        _ = KishuCommand.tag(notebook_key, "at_head", None, "In current time")
+        _ = KishuCommand.tag(notebook_key, "historical", basic_execution_ids[1], "")
+        log_result = KishuCommand.log(notebook_key, basic_execution_ids[-1])
         assert len(log_result.commit_graph) == 3
         assert log_result.commit_graph[0] == CommitSummary(
             commit_id="0:1",
@@ -294,12 +294,12 @@ class TestKishuCommand:
             tags=["at_head"],
         )
 
-    def test_fe_commit_graph(self, notebook_id, basic_execution_ids):
-        fe_commit_graph_result = KishuCommand.fe_commit_graph(notebook_id)
+    def test_fe_commit_graph(self, notebook_key, basic_execution_ids):
+        fe_commit_graph_result = KishuCommand.fe_commit_graph(notebook_key)
         assert len(fe_commit_graph_result.commits) == 3
 
-    def test_fe_commit(self, notebook_id, basic_execution_ids):
-        fe_commit_result = KishuCommand.fe_commit(notebook_id, basic_execution_ids[-1], vardepth=0)
+    def test_fe_commit(self, notebook_key, basic_execution_ids):
+        fe_commit_result = KishuCommand.fe_commit(notebook_key, basic_execution_ids[-1], vardepth=0)
         assert fe_commit_result == FESelectedCommit(
             commit=FECommit(
                 oid="0:3",

--- a/kishu/tests/test_notebook_id.py
+++ b/kishu/tests/test_notebook_id.py
@@ -1,0 +1,45 @@
+import pytest
+
+from pathlib import Path
+from typing import Generator
+
+from kishu.exceptions import MissingNotebookMetadataError, NotNotebookPathOrKey
+from kishu.jupyterint import KishuForJupyter
+from kishu.notebook_id import NotebookId
+
+
+@pytest.fixture()
+def mock_notebook_key() -> Generator[str, None, None]:
+    yield "notebook_123"
+
+
+@pytest.fixture()
+def kishu_jupyter(tmp_kishu_path, mock_notebook_key, set_notebook_path_env) -> Generator[KishuForJupyter, None, None]:
+    kishu_jupyter = KishuForJupyter(notebook_id=NotebookId.from_enclosing_with_key(mock_notebook_key))
+    kishu_jupyter.set_test_mode()
+    yield kishu_jupyter
+
+
+class TestNotebookId:
+    def test_from_enclosing_with_key(self, mock_notebook_key, set_notebook_path_env):
+        notebook_id = NotebookId.from_enclosing_with_key(mock_notebook_key)
+        assert notebook_id.key() == mock_notebook_key
+        assert notebook_id.path() == Path(set_notebook_path_env)
+        assert notebook_id.kernel_id() == "test_kernel_id"
+
+    def test_parse_key_from_path_without_kishu(self, set_notebook_path_env):
+        with pytest.raises(MissingNotebookMetadataError):
+            _ = NotebookId.parse_key_from_path_or_key(set_notebook_path_env)
+
+    @pytest.mark.parametrize("set_notebook_path_env", ["simple_with_kishu.ipynb"], indirect=True)
+    def test_parse_key_from_path(self, set_notebook_path_env):
+        notebook_key = NotebookId.parse_key_from_path_or_key(set_notebook_path_env)
+        assert notebook_key == "simple_kishu_notebook_key"  # From notebook metadata.
+
+    def test_parse_key_from_key(self, kishu_jupyter, mock_notebook_key):
+        notebook_key = NotebookId.parse_key_from_path_or_key(mock_notebook_key)
+        assert notebook_key == mock_notebook_key
+
+    def test_parse_key_neither(self):
+        with pytest.raises(NotNotebookPathOrKey):
+            _ = NotebookId.parse_key_from_path_or_key("non_existent_notebook.ipynb")

--- a/kishu/tests/test_runtime.py
+++ b/kishu/tests/test_runtime.py
@@ -18,25 +18,25 @@ def test_server_with_sessions(mock_servers):
 
 
 def test_enclosing_kernel_id(mock_servers):
-    with patch('kishu.runtime.ipykernel.get_connection_file', return_value="kernel-kernel_id_1.json"):
+    with patch('kishu.runtime.ipykernel.get_connection_file', return_value="kernel-test_kernel_id.json"):
         result = JupyterRuntimeEnv.enclosing_kernel_id()
-    assert result == "kernel_id_1"
+    assert result == "test_kernel_id"
 
 
 def test_notebook_path_from_kernel(mock_servers):
-    result = JupyterRuntimeEnv.notebook_path_from_kernel("kernel_id_1")
+    result = JupyterRuntimeEnv.notebook_path_from_kernel("test_kernel_id")
     assert result == Path("/root/notebook1.ipynb")
 
 
 def test_session_with_root_dir(mock_servers):
     sessions = list(JupyterRuntimeEnv.iter_sessions())
-    expected_session = IPythonSession(kernel_id='kernel_id_1', notebook_path=Path('/root/notebook1.ipynb'))
+    expected_session = IPythonSession(kernel_id='test_kernel_id', notebook_path=Path('/root/notebook1.ipynb'))
     assert sessions == [expected_session]
 
 
 def test_kernel_id_from_notebook(mock_servers):
     kernel_id = JupyterRuntimeEnv.kernel_id_from_notebook(Path("/root/notebook1.ipynb"))
-    assert kernel_id == "kernel_id_1"
+    assert kernel_id == "test_kernel_id"
 
 
 def test_iter_maybe_running_servers_bad_json():


### PR DESCRIPTION
- Refactor Jupyter runtime, notebook metadata, and connection file
- Try parsing given notebook ID string as either a notebook path or a Kishu notebook key

Tested on unit tests and manual checks