### PR TITLE
Migrate to pyproject.toml

### DIFF
--- a/.github/workflows/kishu.yml
+++ b/.github/workflows/kishu.yml
@@ -30,7 +30,7 @@ jobs:
         cd kishu
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        python setup.py install
+        python -m pip install .
         python -c "import kishu, kishu.cli, kishu.backend, kishu.commands"
     - name: Install development dependencies
       run: |

--- a/kishu/dev-requirements.txt
+++ b/kishu/dev-requirements.txt
@@ -1,4 +1,5 @@
 # Packages for development (e.g., checks, tests) in addition to those in requirements.txt
+# README: Keep in sync with pyproject.toml
 
 # Development tools
 flake8

--- a/kishu/pyproject.toml
+++ b/kishu/pyproject.toml
@@ -1,0 +1,87 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+# package-dir = { "" = "kishu" }
+packages = ["kishu"]
+
+[project]
+name = "kishu"
+authors = [
+    {name = "Yongjoo Park", email = "yongjoo@g.illinois.edu"},
+    {name = "Supawit Chockchowwat", email = "supawit2@illinois.edu"},
+    {name = "Zhaoheng Li", email = "zl20@illinois.edu"},
+]
+description = "Intelligent Python Checkpointing"
+readme = "README.md"
+requires-python = ">=3.8"
+keywords = [
+    "kishu", "elastic", "dart",
+    "python", "jupyter", "notebook", "server", "lab", 
+    "cli", "web", "gui", "extension",
+]
+license = {file = "LICENSE"}
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 4",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+version = "0.1.0"  # README: Keep in sync with kishu/__init__.py
+dependencies = [  # README: Keep in sync with requirements.txt
+    # Core
+    "dataclasses",
+    "dataclasses_json",
+    "dill",
+    "ipykernel",
+    "ipylab",
+    "jupyter_ui_poll",
+    "nbconvert",
+    "nbformat",
+    "networkx",
+    "psutil",
+    "typing",
+
+    # User interfaces: cli, backend, jupyterlab_kishu
+    "flask",
+    "typer",
+
+    # Planning
+    "numpy",
+    "pandas",
+    "shortuuid",
+    "xxhash",
+
+    # Watchdog
+    "loguru",
+]
+
+[project.optional-dependencies]
+dev = [  # README: Keep in sync with dev-requirements.txt
+    # Development tools
+    "flake8",
+    "mypy",
+    "pytest",
+    "pytest-cov",
+
+    # Test cases
+    "matplotlib",
+    "numpy",
+    "scikit-learn",
+    "seaborn",
+    "textblob",
+    "pandas",
+]
+
+
+[project.scripts]
+kishu = "kishu.cli:main"
+
+[project.urls]
+repository = "https://github.com/illinoisdata/kishu"

--- a/kishu/requirements.txt
+++ b/kishu/requirements.txt
@@ -1,4 +1,5 @@
 # Packages required to import kishu.
+# README: Keep in sync with pyproject.toml
 
 # Core
 dataclasses

--- a/kishu/setup.py
+++ b/kishu/setup.py
@@ -2,7 +2,7 @@
 
 # Learn more: https://github.com/kennethreitz/setup.py
 
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, Extension
 
 
 class get_numpy_include(object):
@@ -12,24 +12,8 @@ class get_numpy_include(object):
         return numpy.get_include()
 
 
-with open('README.md') as f:
-    readme = f.read()
-
-with open('LICENSE') as f:
-    license = f.read()
-
-
-setup(
-    name='kishu',
-    version='0.1.0',
-    description='Intelligent Python Checkpointing',
-    long_description=readme,
-    author='Yongjoo Park',
-    author_email='yongjoo@g.illinois.edu',
-    url='https://github.com/illinoisdata/kishu',
-    license=license,
-    packages=find_packages(exclude=('tests', 'docs', 'examples')),
-    setup_requires=["numpy"],
+# Dynamic metadata in addition to static one in pyproject.toml
+setup_args = dict(
     ext_modules=[
         Extension(
             "c_idgraph",
@@ -37,9 +21,5 @@ setup(
             include_dirs=[get_numpy_include()],
         ),
     ],
-    entry_points={
-        'console_scripts': [
-            'kishu = kishu.cli:main',
-        ],
-    },
 )
+setup(**setup_args)


### PR DESCRIPTION
[PEP 621](https://peps.python.org/pep-0621/): `setup.py` is deprecated in favor of `pyproject.toml`