### PR TITLE
Disambiguate commit prefixes to commit ID

### DIFF
--- a/kishu/kishu/commands.py
+++ b/kishu/kishu/commands.py
@@ -202,6 +202,7 @@ class KishuCommand:
         if commit_id is None:
             return LogResult([])
 
+        commit_id = KishuForJupyter.disambiguate_commit(notebook_id, commit_id)
         store = KishuCommitGraph.new_on_file(KishuPath.commit_graph_directory(notebook_id))
         graph = store.list_history(commit_id)
         return LogResult(KishuCommand._decorate_graph(notebook_id, graph))
@@ -214,6 +215,7 @@ class KishuCommand:
 
     @staticmethod
     def status(notebook_id: str, commit_id: str) -> StatusResult:
+        commit_id = KishuForJupyter.disambiguate_commit(notebook_id, commit_id)
         commit_node_info = next(
             KishuCommitGraph.new_on_file(KishuPath.commit_graph_directory(notebook_id))
                             .iter_history(commit_id)
@@ -258,11 +260,12 @@ class KishuCommand:
             head = KishuBranch.update_head(notebook_id, is_detach=True)
             print(f"detaching {head}")
 
-        # Fail to determine commit ID, possibly because a commit does not exist.
+        # Fail to determine commit ID, possibly because no commit does not exist.
         if commit_id is None:
             return BranchResult(status="no_commit")
 
         # Now add this branch.
+        commit_id = KishuForJupyter.disambiguate_commit(notebook_id, commit_id)
         KishuBranch.upsert_branch(notebook_id, branch_name, commit_id)
 
         # Create new commit for this branch action.
@@ -312,6 +315,7 @@ class KishuCommand:
             return TagResult(status="no_commit")
 
         # Now add this tag.
+        commit_id = KishuForJupyter.disambiguate_commit(notebook_id, commit_id)
         tag = TagRow(tag_name=tag_name, commit_id=commit_id, message=message)
         KishuTag.upsert_tag(notebook_id, tag)
         return TagResult(
@@ -362,6 +366,7 @@ class KishuCommand:
 
     @staticmethod
     def fe_commit(notebook_id: str, commit_id: str, vardepth: int) -> FESelectedCommit:
+        commit_id = KishuForJupyter.disambiguate_commit(notebook_id, commit_id)
         commit_node_info = next(
             KishuCommitGraph.new_on_file(KishuPath.commit_graph_directory(notebook_id))
                             .iter_history(commit_id)

--- a/kishu/kishu/planning/plan.py
+++ b/kishu/kishu/planning/plan.py
@@ -13,6 +13,7 @@ from kishu.storage.checkpoint_io import (
     get_log,
     get_log_item,
     get_log_items,
+    keys_like,
     store_checkpoint,
     store_log_item,
 )
@@ -49,6 +50,10 @@ class UnitExecution:
         if len(data) == 0:
             return None
         return dill.loads(data)
+
+    @staticmethod
+    def keys_from_db_like(checkpoint_file: str, commit_id_like: str) -> List[str]:
+        return keys_like(checkpoint_file, commit_id_like)
 
     @staticmethod
     def get_commits(checkpoint_file: str, commit_ids: List[str]) -> Dict[str, UnitExecution]:

--- a/kishu/kishu/storage/checkpoint_io.py
+++ b/kishu/kishu/storage/checkpoint_io.py
@@ -75,9 +75,19 @@ def get_log_item(dbfile: str, commit_id: str) -> bytes:
     cur.execute(
         "select data from {} where commit_id = ?".format(HISTORY_LOG_TABLE),
         (commit_id, )
-        )
+    )
     res: tuple = cur.fetchone()
     return res[0] if res else bytes()
+
+
+def keys_like(dbfile: str, commit_id_like: str) -> List[str]:
+    con = sqlite3.connect(dbfile)
+    cur = con.cursor()
+    cur.execute(
+        "select commit_id from {} where commit_id LIKE ?".format(HISTORY_LOG_TABLE),
+        (commit_id_like + "%", )
+    )
+    return [commit_id for (commit_id,) in cur.fetchall()]
 
 
 def get_log_items(dbfile: str, commit_ids: List[str]) -> Dict[str, bytes]:

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -1,58 +1,9 @@
-import dataclasses
 import os
-import pytest
-
-from typing import Generator, List, Optional
 
 from kishu.commands import CommitSummary, FECommit, FESelectedCommit, KishuCommand, KishuSession
-from kishu.jupyterint import CommitEntryKind, CommitEntry, KishuForJupyter
-from kishu.notebook_id import NotebookId
+from kishu.jupyterint import CommitEntryKind, CommitEntry
 from kishu.storage.branch import KishuBranch
 from kishu.storage.commit_graph import CommitNodeInfo
-
-
-@pytest.fixture()
-def notebook_key() -> Generator[str, None, None]:
-    yield "notebook_123"
-
-
-@pytest.fixture()
-def kishu_jupyter(tmp_kishu_path, notebook_key, set_notebook_path_env) -> Generator[KishuForJupyter, None, None]:
-    kishu_jupyter = KishuForJupyter(notebook_id=NotebookId.from_enclosing_with_key(notebook_key))
-    kishu_jupyter.set_test_mode()
-    yield kishu_jupyter
-
-
-@pytest.fixture()
-def basic_execution_ids(kishu_jupyter) -> Generator[List[str], None, None]:
-    execution_count = 1
-    info = JupyterInfoMock(raw_cell="x = 1")
-    kishu_jupyter.pre_run_cell(info)
-    kishu_jupyter.post_run_cell(JupyterResultMock(info=info, execution_count=execution_count))
-    execution_count = 2
-    info = JupyterInfoMock(raw_cell="y = 2")
-    kishu_jupyter.pre_run_cell(info)
-    kishu_jupyter.post_run_cell(JupyterResultMock(info=info, execution_count=execution_count))
-    execution_count = 3
-    info = JupyterInfoMock(raw_cell="y = x + 1")
-    kishu_jupyter.pre_run_cell(info)
-    kishu_jupyter.post_run_cell(JupyterResultMock(info=info, execution_count=execution_count))
-
-    yield ["0:1", "0:2", "0:3"]  # List of commit IDs
-
-
-@dataclasses.dataclass
-class JupyterInfoMock:
-    raw_cell: Optional[str] = None
-
-
-@dataclasses.dataclass
-class JupyterResultMock:
-    info: JupyterInfoMock = dataclasses.field(default_factory=JupyterInfoMock)
-    execution_count: Optional[int] = None
-    error_before_exec: Optional[str] = None
-    error_in_exec: Optional[str] = None
-    result: Optional[str] = None
 
 
 class TestKishuCommand:

--- a/kishu/tests/test_jupyterint.py
+++ b/kishu/tests/test_jupyterint.py
@@ -4,9 +4,9 @@ import nbformat
 import pytest
 
 from pathlib import Path
-from typing import Any
+from typing import Any, List
 
-from kishu.jupyterint import CommitEntry
+from kishu.jupyterint import CommitEntry, KishuForJupyter
 from kishu.planning.plan import ExecutionHistory
 from kishu.storage.checkpoint_io import init_checkpoint_database
 
@@ -34,127 +34,163 @@ def test_history_to_sqlite(tmp_path: Path):
     assert retrieved_item == commit_entry
 
 
-# Modify the test_checkout to use the new fixture.
-@pytest.mark.parametrize("set_notebook_path_env", ["test_jupyter_checkout.ipynb"], indirect=True)
-def test_checkout(tmp_kishu_path_os: Path, set_notebook_path_env):
-    notebook = NotebookRunner(set_notebook_path_env)
-    vals = ['a']
-    output = notebook.execute([], vals)
-    assert output['a'] == 1
+class TestOnMockEnclosing:
+    def test_disambiguate_commit_pass(
+        self,
+        kishu_jupyter: KishuForJupyter,
+        notebook_key: str,
+        basic_execution_ids: List[str],
+    ) -> None:
+        commit_ids = basic_execution_ids
+        assert KishuForJupyter.disambiguate_commit(notebook_key, commit_ids[0]) == commit_ids[0]
+        assert KishuForJupyter.disambiguate_commit(notebook_key, commit_ids[1]) == commit_ids[1]
+        assert KishuForJupyter.disambiguate_commit(notebook_key, commit_ids[2]) == commit_ids[2]
+
+    def test_disambiguate_commit_not_exist(
+        self,
+        kishu_jupyter: KishuForJupyter,
+        notebook_key: str,
+        basic_execution_ids: List[str],
+    ) -> None:
+        with pytest.raises(ValueError):
+            _ = KishuForJupyter.disambiguate_commit(notebook_key, "NON_EXISTENT_COMMIT_ID")
+
+    def test_disambiguate_commit_ambiguous(
+        self,
+        kishu_jupyter: KishuForJupyter,
+        notebook_key: str,
+        basic_execution_ids: List[str],
+    ) -> None:
+        commit_ids = basic_execution_ids
+        common_prefix = commit_ids[0][:1]
+        assert sum(common_prefix in commit_id for commit_id in commit_ids) > 1, f"No common prefix {commit_ids}"
+        with pytest.raises(ValueError):
+            _ = KishuForJupyter.disambiguate_commit(notebook_key, common_prefix)
 
 
-@pytest.mark.parametrize("set_notebook_path_env", ["test_init_kishu.ipynb"], indirect=True)
-def test_reattatchment(tmp_kishu_path_os: Path, set_notebook_path_env):
-    notebook = NotebookRunner(set_notebook_path_env)
-    vals = ['a']
-    output = notebook.execute([], vals)
-    assert output['a'] == 1
+class TestOnNotebookRunner:
 
-    with open(set_notebook_path_env, "r") as temp_file:
-        nb = nbformat.read(temp_file, 4)
-        assert nb.metadata.kishu.session_count == 2
+    # Modify the test_checkout to use the new fixture.
+    @pytest.mark.parametrize("set_notebook_path_env", ["test_jupyter_checkout.ipynb"], indirect=True)
+    def test_checkout(self, tmp_kishu_path_os: Path, set_notebook_path_env):
+        notebook = NotebookRunner(set_notebook_path_env)
+        vals = ['a']
+        output = notebook.execute([], vals)
+        assert output['a'] == 1
 
+    @pytest.mark.parametrize("set_notebook_path_env", ["test_init_kishu.ipynb"], indirect=True)
+    def test_reattatchment(self, tmp_kishu_path_os: Path, set_notebook_path_env):
+        notebook = NotebookRunner(set_notebook_path_env)
+        vals = ['a']
+        output = notebook.execute([], vals)
+        assert output['a'] == 1
 
-@pytest.mark.parametrize("set_notebook_path_env", ["test_jupyter_load_module.ipynb"], indirect=True)
-def test_record_history(tmp_kishu_path_os: Path, set_notebook_path_env):
-    notebook = NotebookRunner(set_notebook_path_env)
-    exprs = {"history": "repr(_kishu.log())"}
-    output = notebook.execute([], [], exprs)
+        with open(set_notebook_path_env, "r") as temp_file:
+            nb = nbformat.read(temp_file, 4)
+            assert nb.metadata.kishu.session_count == 2
 
-    # The first two cells are something we use for testing. Additional cells appear in the history
-    # because of the way NotebookRunner runs.
+    @pytest.mark.parametrize("set_notebook_path_env", ["test_jupyter_load_module.ipynb"], indirect=True)
+    def test_record_history(self, tmp_kishu_path_os: Path, set_notebook_path_env):
+        notebook = NotebookRunner(set_notebook_path_env)
+        exprs = {"history": "repr(_kishu.log())"}
+        output = notebook.execute([], [], exprs)
 
-    def set_field_to(dict_obj: dict, field: str, value: Any):
-        if field not in dict_obj:
-            return
-        dict_obj[field] = value
+        # The first two cells are something we use for testing. Additional cells appear in the history
+        # because of the way NotebookRunner runs.
 
-    def replace_start_time(commit_entry):
-        set_field_to(commit_entry, 'checkpoint_runtime_ms', 0)
-        set_field_to(commit_entry, 'timestamp_ms', 0)
-        set_field_to(commit_entry, 'end_time_ms', 0)
-        set_field_to(commit_entry, 'runtime_ms', 0)
-        set_field_to(commit_entry, 'start_time_ms', 0)
-        set_field_to(commit_entry, 'message', "")
-        set_field_to(commit_entry, 'ahg_string', "")
-        set_field_to(commit_entry, 'formatted_cells', [])
-        set_field_to(commit_entry, 'raw_nb', "")
-        set_field_to(commit_entry, 'code_version', 0)
-        set_field_to(commit_entry, 'var_version', 0)
-        return commit_entry
+        def set_field_to(dict_obj: dict, field: str, value: Any):
+            if field not in dict_obj:
+                return
+            dict_obj[field] = value
 
-    # TODO: This test is hacky; we ought to reach for list of commits through public methods.
-    history_dict = json.loads(output['history'])
-    assert replace_start_time(history_dict['1:1']) == {
-            "checkpoint_runtime_ms": 0,
-            "code_block": "from kishu import init_kishu\ninit_kishu()\n_kishu.set_test_mode()",
-            "end_time_ms": 0,
-            "exec_id": "1:1",
-            "execution_count": 1,
-            'executed_cells': [
-                '',
-                'from kishu import init_kishu\ninit_kishu()\n_kishu.set_test_mode()',
-            ],
-            "kind": "jupyter",
-            "formatted_cells": [],
-            "raw_nb": "",
-            "message": "",
-            "ahg_string": "",
-            "code_version": 0,
-            "var_version": 0,
-            "timestamp_ms": 0,
-        }
-    assert replace_start_time(history_dict['1:2']) == {
-            "checkpoint_runtime_ms": 0,
-            "checkpoint_vars": ["a"],
-            "code_block": "a = 1",
-            "end_time_ms": 0,
-            "exec_id": "1:2",
-            'executed_cells': [
-                '',
-                'from kishu import init_kishu\ninit_kishu()\n_kishu.set_test_mode()',
-                'a = 1',
-            ],
-            "execution_count": 2,
-            "runtime_ms": 0,
-            "start_time_ms": 0,
-            "kind": "jupyter",
-            "message": "",
-            "ahg_string": "",
-            "formatted_cells": [],
-            "raw_nb": "",
-            "code_version": 0,
-            "var_version": 0,
-            "timestamp_ms": 0,
-        }
+        def replace_start_time(commit_entry):
+            set_field_to(commit_entry, 'checkpoint_runtime_ms', 0)
+            set_field_to(commit_entry, 'timestamp_ms', 0)
+            set_field_to(commit_entry, 'end_time_ms', 0)
+            set_field_to(commit_entry, 'runtime_ms', 0)
+            set_field_to(commit_entry, 'start_time_ms', 0)
+            set_field_to(commit_entry, 'message', "")
+            set_field_to(commit_entry, 'ahg_string', "")
+            set_field_to(commit_entry, 'formatted_cells', [])
+            set_field_to(commit_entry, 'raw_nb', "")
+            set_field_to(commit_entry, 'code_version', 0)
+            set_field_to(commit_entry, 'var_version', 0)
+            return commit_entry
 
+        # TODO: This test is hacky; we ought to reach for list of commits through public methods.
+        history_dict = json.loads(output['history'])
+        assert replace_start_time(history_dict['1:1']) == {
+                "checkpoint_runtime_ms": 0,
+                "code_block": "from kishu import init_kishu\ninit_kishu()\n_kishu.set_test_mode()",
+                "end_time_ms": 0,
+                "exec_id": "1:1",
+                "execution_count": 1,
+                'executed_cells': [
+                    '',
+                    'from kishu import init_kishu\ninit_kishu()\n_kishu.set_test_mode()',
+                ],
+                "kind": "jupyter",
+                "formatted_cells": [],
+                "raw_nb": "",
+                "message": "",
+                "ahg_string": "",
+                "code_version": 0,
+                "var_version": 0,
+                "timestamp_ms": 0,
+            }
+        assert replace_start_time(history_dict['1:2']) == {
+                "checkpoint_runtime_ms": 0,
+                "checkpoint_vars": ["a"],
+                "code_block": "a = 1",
+                "end_time_ms": 0,
+                "exec_id": "1:2",
+                'executed_cells': [
+                    '',
+                    'from kishu import init_kishu\ninit_kishu()\n_kishu.set_test_mode()',
+                    'a = 1',
+                ],
+                "execution_count": 2,
+                "runtime_ms": 0,
+                "start_time_ms": 0,
+                "kind": "jupyter",
+                "message": "",
+                "ahg_string": "",
+                "formatted_cells": [],
+                "raw_nb": "",
+                "code_version": 0,
+                "var_version": 0,
+                "timestamp_ms": 0,
+            }
 
-@pytest.mark.parametrize(
-    ("set_notebook_path_env", "cell_num_to_restore"),
-    [
-        ('simple.ipynb', 2),
-        ('simple.ipynb', 3),
-        ('numpy.ipynb', 2),
-        ('numpy.ipynb', 3),
-        ('numpy.ipynb', 4),
-        pytest.param('ml-ex1.ipynb', 10, marks=pytest.mark.skip(reason="Too expensive to run")),
-        pytest.param('04_training_linear_models.ipynb', 10, marks=pytest.mark.skip(reason="Too expensive to run")),
-        pytest.param('sklearn_tweet_classification.ipynb', 10, marks=pytest.mark.skip(reason="Too expensive to run"))
-    ],
-    indirect=["set_notebook_path_env"]
-)
-def test_full_checkout(tmp_kishu_path_os: Path, set_notebook_path_env, cell_num_to_restore: int):
-    """
-    Tests checkout correctness by comparing namespace contents at cell_num_to_restore in the middle of a notebook,
-    and namespace contents after checking out cell_num_to_restore completely executing the notebook.
-    """
-    notebook = NotebookRunner(set_notebook_path_env)
+    @pytest.mark.parametrize(
+        ("set_notebook_path_env", "cell_num_to_restore"),
+        [
+            ('simple.ipynb', 2),
+            ('simple.ipynb', 3),
+            ('numpy.ipynb', 2),
+            ('numpy.ipynb', 3),
+            ('numpy.ipynb', 4),
+            pytest.param('ml-ex1.ipynb', 10,
+                         marks=pytest.mark.skip(reason="Too expensive to run")),
+            pytest.param('04_training_linear_models.ipynb', 10,
+                         marks=pytest.mark.skip(reason="Too expensive to run")),
+            pytest.param('sklearn_tweet_classification.ipynb', 10,
+                         marks=pytest.mark.skip(reason="Too expensive to run"))
+        ],
+        indirect=["set_notebook_path_env"]
+    )
+    def test_full_checkout(self, tmp_kishu_path_os: Path, set_notebook_path_env, cell_num_to_restore: int):
+        """
+        Tests checkout correctness by comparing namespace contents at cell_num_to_restore in the middle of a notebook,
+        and namespace contents after checking out cell_num_to_restore completely executing the notebook.
+        """
+        notebook = NotebookRunner(set_notebook_path_env)
 
-    # Get notebook namespace contents at cell execution X and contents after checking out cell execution X.
-    namespace_before_checkout, namespace_after_checkout = notebook.execute_full_checkout_test(cell_num_to_restore)
+        # Get notebook namespace contents at cell execution X and contents after checking out cell execution X.
+        namespace_before_checkout, namespace_after_checkout = notebook.execute_full_checkout_test(cell_num_to_restore)
 
-    # The contents should be identical.
-    assert namespace_before_checkout.keys() == namespace_after_checkout.keys()
-    for key in namespace_before_checkout.keys():
-        # As certain classes don't have equality (__eq__) implemented, we compare serialized bytestrings.
-        assert dill.dumps(namespace_before_checkout[key]) == dill.dumps(namespace_after_checkout[key])
+        # The contents should be identical.
+        assert namespace_before_checkout.keys() == namespace_after_checkout.keys()
+        for key in namespace_before_checkout.keys():
+            # As certain classes don't have equality (__eq__) implemented, we compare serialized bytestrings.
+            assert dill.dumps(namespace_before_checkout[key]) == dill.dumps(namespace_after_checkout[key])


### PR DESCRIPTION
- Moving to full UUID4 commit IDs will make them harder to copy-paste
- Allow commit ID prefix as the input to all related commands
- Disambiguate commit ID prefixes by matching to commit entries

Tested in unit tests and manual checks