### PR TITLE
Check notebook metadata on list + clarify CLI notebook path argument

### DIFF
--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -83,10 +83,9 @@ def detach(
 
 @kishu_app.command()
 def log(
-    notebook_key: str = typer.Argument(
+    notebook_path_or_key: str = typer.Argument(
         ...,
-        parser=NotebookId.parse_key_from_path_or_key,
-        help="Notebook ID to interact with.",
+        help="Path to the target notebook or Kishu notebook key.",
         show_default=False
     ),
     commit_id: str = typer.Argument(
@@ -104,6 +103,7 @@ def log(
     """
     Show a history view of commit graph.
     """
+    notebook_key = NotebookId.parse_key_from_path_or_key(notebook_path_or_key)
     if log_all:
         print(into_json(KishuCommand.log_all(notebook_key)))
     else:
@@ -112,10 +112,9 @@ def log(
 
 @kishu_app.command()
 def status(
-    notebook_key: str = typer.Argument(
+    notebook_path_or_key: str = typer.Argument(
         ...,
-        parser=NotebookId.parse_key_from_path_or_key,
-        help="Notebook ID to interact with.",
+        help="Path to the target notebook or Kishu notebook key.",
         show_default=False
     ),
     commit_id: str = typer.Argument(..., help="Commit ID to get status.", show_default=False),
@@ -123,15 +122,15 @@ def status(
     """
     Show a commit in detail.
     """
+    notebook_key = NotebookId.parse_key_from_path_or_key(notebook_path_or_key)
     print(into_json(KishuCommand.status(notebook_key, commit_id)))
 
 
 @kishu_app.command()
 def commit(
-    notebook_key: str = typer.Argument(
+    notebook_path_or_key: str = typer.Argument(
         ...,
-        parser=NotebookId.parse_key_from_path_or_key,
-        help="Notebook ID to interact with.",
+        help="Path to the target notebook or Kishu notebook key.",
         show_default=False
     ),
     message: str = typer.Option(
@@ -145,15 +144,15 @@ def commit(
     """
     Checkout a notebook to a commit.
     """
+    notebook_key = NotebookId.parse_key_from_path_or_key(notebook_path_or_key)
     print(into_json(KishuCommand.commit(notebook_key, message=message)))
 
 
 @kishu_app.command()
 def checkout(
-    notebook_key: str = typer.Argument(
+    notebook_path_or_key: str = typer.Argument(
         ...,
-        parser=NotebookId.parse_key_from_path_or_key,
-        help="Notebook ID to interact with.",
+        help="Path to the target notebook or Kishu notebook key.",
         show_default=False
     ),
     branch_or_commit_id: str = typer.Argument(
@@ -171,6 +170,7 @@ def checkout(
     """
     Checkout a notebook to a commit.
     """
+    notebook_key = NotebookId.parse_key_from_path_or_key(notebook_path_or_key)
     print(into_json(KishuCommand.checkout(
         notebook_key,
         branch_or_commit_id,
@@ -180,10 +180,9 @@ def checkout(
 
 @kishu_app.command()
 def branch(
-    notebook_key: str = typer.Argument(
+    notebook_path_or_key: str = typer.Argument(
         ...,
-        parser=NotebookId.parse_key_from_path_or_key,
-        help="Notebook ID to interact with.",
+        help="Path to the target notebook or Kishu notebook key.",
         show_default=False
     ),
     commit_id: str = typer.Argument(
@@ -219,6 +218,7 @@ def branch(
     """
     Create, rename, or delete branches.
     """
+    notebook_key = NotebookId.parse_key_from_path_or_key(notebook_path_or_key)
     if create_branch_name is not None:
         print(into_json(KishuCommand.branch(notebook_key, create_branch_name, commit_id)))
     if delete_branch_name is not None:
@@ -232,10 +232,9 @@ def branch(
 
 @kishu_app.command()
 def tag(
-    notebook_key: str = typer.Argument(
+    notebook_path_or_key: str = typer.Argument(
         ...,
-        parser=NotebookId.parse_key_from_path_or_key,
-        help="Notebook ID to interact with.",
+        help="Path to the target notebook or Kishu notebook key.",
         show_default=False
     ),
     tag_name: str = typer.Argument(
@@ -257,6 +256,7 @@ def tag(
     """
     Create or edit tags.
     """
+    notebook_key = NotebookId.parse_key_from_path_or_key(notebook_path_or_key)
     print(into_json(KishuCommand.tag(notebook_key, tag_name, commit_id, message)))
 
 
@@ -270,25 +270,24 @@ kishu_experimental_app = typer.Typer(add_completion=False)
 
 @kishu_experimental_app.command()
 def fegraph(
-    notebook_key: str = typer.Argument(
+    notebook_path_or_key: str = typer.Argument(
         ...,
-        parser=NotebookId.parse_key_from_path_or_key,
-        help="Notebook ID to interact with.",
+        help="Path to the target notebook or Kishu notebook key.",
         show_default=False
     ),
 ) -> None:
     """
     Show the frontend commit graph.
     """
+    notebook_key = NotebookId.parse_key_from_path_or_key(notebook_path_or_key)
     print(into_json(KishuCommand.fe_commit_graph(notebook_key)))
 
 
 @kishu_experimental_app.command()
 def fecommit(
-    notebook_key: str = typer.Argument(
+    notebook_path_or_key: str = typer.Argument(
         ...,
-        parser=NotebookId.parse_key_from_path_or_key,
-        help="Notebook ID to interact with.",
+        help="Path to the target notebook or Kishu notebook key.",
         show_default=False
     ),
     commit_id: str = typer.Argument(..., help="Commit ID to get detail.", show_default=False),
@@ -301,6 +300,7 @@ def fecommit(
     """
     Show the commit in frontend detail.
     """
+    notebook_key = NotebookId.parse_key_from_path_or_key(notebook_path_or_key)
     print(into_json(KishuCommand.fe_commit(notebook_key, commit_id, vardepth)))
 
 

--- a/kishu/kishu/notebook_id.py
+++ b/kishu/kishu/notebook_id.py
@@ -45,13 +45,17 @@ class NotebookId:
         return NotebookId(key=key, path=path, kernel_id=kernel_id)
 
     @staticmethod
+    def parse_key_from_path(path: Path) -> str:
+        nb = JupyterRuntimeEnv.read_notebook(path)
+        metadata = NotebookId.read_kishu_metadata(nb)
+        return metadata.notebook_id
+
+    @staticmethod
     def parse_key_from_path_or_key(path_or_key: str) -> str:
         # Try parsing as path, if exists.
         path = Path(path_or_key)
         if path.exists():
-            nb = JupyterRuntimeEnv.read_notebook(path)
-            metadata = NotebookId.read_kishu_metadata(nb)
-            return metadata.notebook_id
+            return NotebookId.parse_key_from_path(path)
 
         # Notebook path does not exist, try parsing as key.
         key = path_or_key

--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import shutil
 
 from pathlib import Path, PurePath
-from typing import Generator, List, Optional, Type
+from typing import Callable, Generator, List, Optional, Type
 from unittest.mock import patch
 
 from kishu.backend import app as kishu_app
@@ -60,11 +60,18 @@ KISHU_TEST_NOTEBOOKS_DIR = "notebooks"
 
 
 @pytest.fixture()
-def nb_simple_path(tmp_path: Path, kishu_test_dir: Path) -> Path:
-    real_nb_path = kishu_test_dir / PurePath(KISHU_TEST_NOTEBOOKS_DIR, "simple.ipynb")
-    tmp_nb_path = tmp_path / PurePath("simple.ipynb")
-    shutil.copy(real_nb_path, tmp_nb_path)
-    return tmp_nb_path
+def tmp_nb_path(tmp_path: Path, kishu_test_dir: Path) -> Callable[[str], Path]:
+    def _tmp_nb_path(notebook_name: str) -> Path:
+        real_nb_path = kishu_test_dir / PurePath(KISHU_TEST_NOTEBOOKS_DIR, notebook_name)
+        tmp_nb_path = tmp_path / PurePath(notebook_name)
+        shutil.copy(real_nb_path, tmp_nb_path)
+        return tmp_nb_path
+    return _tmp_nb_path
+
+
+@pytest.fixture()
+def nb_simple_path(tmp_nb_path: Callable[[str], Path]) -> Path:
+    return tmp_nb_path("simple.ipynb")
 
 
 """

--- a/kishu/tests/helpers/nbexec.py
+++ b/kishu/tests/helpers/nbexec.py
@@ -31,7 +31,8 @@ NB_DIR: str = "tests/notebooks"
 
 
 # Breaks test_full_checkout in test_jupyterint when using init_kishu
-KISHU_INIT_STR: str = "from kishu import load_kishu; load_kishu(); _kishu.set_test_mode()"
+KISHU_LOAD_STR: str = "from kishu import load_kishu; load_kishu(); _kishu.set_test_mode()"
+KISHU_INIT_STR: str = "from kishu import init_kishu; init_kishu(); _kishu.set_test_mode()"
 
 
 def get_kishu_checkout_str(cell_num: int, session_num: int = 0) -> str:
@@ -151,7 +152,7 @@ class NotebookRunner:
         assert cell_num_to_restore >= 2 and cell_num_to_restore <= len(notebook["cells"]) - 1
 
         # create a kishu initialization cell and add it to the start of the notebook.
-        notebook.cells.insert(0, new_code_cell(source=KISHU_INIT_STR))
+        notebook.cells.insert(0, new_code_cell(source=KISHU_LOAD_STR))
 
         # Insert dump session code at middle of notebook after the **cell_num_to_restore**th code cell.
         dumpsession_code_middle = get_dump_namespace_str(self.pickle_file + ".middle")

--- a/kishu/tests/test_runtime.py
+++ b/kishu/tests/test_runtime.py
@@ -2,18 +2,17 @@ import pytest
 import json
 from unittest.mock import patch
 from pathlib import Path
-from kishu.runtime import IPythonSession, JupyterRuntimeEnv, _iter_maybe_running_servers, \
-    _iter_maybe_sessions, _get_sessions
+from kishu.runtime import IPythonSession, JupyterRuntimeEnv
 from .conftest import MOCK_SERVER, MOCK_SESSION
 
 
 def test_iter_maybe_running_servers(mock_servers):
-    result = list(_iter_maybe_running_servers())
+    result = list(JupyterRuntimeEnv.iter_maybe_running_servers())
     assert result == mock_servers
 
 
 def test_server_with_sessions(mock_servers):
-    sessions = list(_iter_maybe_sessions())
+    sessions = list(JupyterRuntimeEnv.iter_maybe_sessions())
     assert sessions == [(MOCK_SERVER, MOCK_SESSION)]
 
 
@@ -41,13 +40,13 @@ def test_kernel_id_from_notebook(mock_servers):
 
 def test_iter_maybe_running_servers_bad_json():
     with patch('kishu.runtime.json.loads', side_effect=json.JSONDecodeError("", "", 0)):
-        result = list(_iter_maybe_running_servers())
+        result = list(JupyterRuntimeEnv.iter_maybe_running_servers())
     assert not result  # should return an empty list
 
 
 def test_get_sessions_raises_exception():
     with patch('kishu.runtime.urllib.request.urlopen', side_effect=Exception):
-        sessions = _get_sessions({"url": "http://localhost:8888/", "token": "token_value"})
+        sessions = JupyterRuntimeEnv.get_sessions({"url": "http://localhost:8888/", "token": "token_value"})
     assert not sessions
 
 


### PR DESCRIPTION
- `kishu list` now double-checks the metadata in notebook, on top of the kernel
  - Move to `init_kishu` in unit tests to write Kishu metadata
- Rename CLI notebook path/key arguments