### PR TITLE
Plumb cookies from handler + untangle init_kishu enclosing path

### DIFF
--- a/kishu/kishu/commands.py
+++ b/kishu/kishu/commands.py
@@ -208,31 +208,33 @@ class KishuCommand:
         return ListResult(sessions=sessions)
 
     @staticmethod
-    def init(notebook_path: str) -> InitResult:
+    def init(notebook_path_str: str) -> InitResult:
+        notebook_path = Path(notebook_path_str)
         try:
-            kernel_id = JupyterRuntimeEnv.kernel_id_from_notebook(Path(notebook_path))
+            kernel_id = JupyterRuntimeEnv.kernel_id_from_notebook(notebook_path)
         except FileNotFoundError as e:
             return InitResult(
                 status="error",
                 message=f"{type(e).__name__}: {str(e)}",
             )
         return InitResult.wrap(JupyterConnection(kernel_id).execute_one_command(
-            pre_command="from kishu import init_kishu; init_kishu()",
+            pre_command=f"from kishu import init_kishu; init_kishu(\"{notebook_path.resolve()}\")",
             command="str(_kishu)",
         ))
 
     @staticmethod
-    def detach(notebook_path: str) -> DetachResult:
+    def detach(notebook_path_str: str) -> DetachResult:
+        notebook_path = Path(notebook_path_str)
         try:
-            kernel_id = JupyterRuntimeEnv.kernel_id_from_notebook(Path(notebook_path))
+            kernel_id = JupyterRuntimeEnv.kernel_id_from_notebook(notebook_path)
         except FileNotFoundError as e:
             return DetachResult(
                 status="error",
                 message=f"{type(e).__name__}: {str(e)}",
             )
         return DetachResult.wrap(JupyterConnection(kernel_id).execute_one_command(
-            pre_command="from kishu import detach_kishu; detach_kishu()",
-            command=f"\"Successfully detatched notebook at {notebook_path}\"",
+            pre_command=f"from kishu import detach_kishu; detach_kishu(\"{notebook_path.resolve()}\")",
+            command=f"\"Successfully detatched notebook at {notebook_path.resolve()}\"",
         ))
 
     @staticmethod

--- a/kishu/kishu/notebook_id.py
+++ b/kishu/kishu/notebook_id.py
@@ -45,6 +45,11 @@ class NotebookId:
         return NotebookId(key=key, path=path, kernel_id=kernel_id)
 
     @staticmethod
+    def from_enclosing_with_key_and_path(key: str, path: Path) -> NotebookId:
+        kernel_id = JupyterRuntimeEnv.enclosing_kernel_id()
+        return NotebookId(key=key, path=path, kernel_id=kernel_id)
+
+    @staticmethod
     def parse_key_from_path(path: Path) -> str:
         nb = JupyterRuntimeEnv.read_notebook(path)
         metadata = NotebookId.read_kishu_metadata(nb)

--- a/kishu/pyproject.toml
+++ b/kishu/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [  # README: Keep in sync with requirements.txt
     "nbformat",
     "networkx",
     "psutil",
+    "requests",
     "typing",
 
     # User interfaces: cli, backend, jupyterlab_kishu

--- a/kishu/requirements.txt
+++ b/kishu/requirements.txt
@@ -12,6 +12,7 @@ nbconvert
 nbformat
 networkx
 psutil
+requests
 typing
 
 # User interfaces: cli, backend, jupyterlab_kishu

--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -2,6 +2,7 @@ import dataclasses
 import json
 import os
 import pytest
+import requests
 import shutil
 
 from pathlib import Path, PurePath
@@ -106,13 +107,14 @@ def glob_side_effect(pattern):
 # used to test runtime.py
 @pytest.fixture
 def mock_servers():
+    resp = requests.Response()
+    resp.status_code = 200
+    resp._content = json.dumps([MOCK_SESSION])
     with patch('kishu.runtime.Path.read_bytes', return_value=json.dumps(MOCK_SERVER).encode()), \
          patch('kishu.runtime.psutil.pid_exists', return_value=True), \
          patch('kishu.runtime.Path.glob', side_effect=glob_side_effect), \
          patch("kishu.runtime.jupyter_core.paths.jupyter_runtime_dir", return_value=Path("/")), \
-         patch('kishu.runtime.urllib.request.urlopen') as mock_urlopen:
-
-        mock_urlopen.return_value.__enter__.return_value.read.return_value = json.dumps([MOCK_SESSION]).encode()
+         patch('kishu.runtime.requests.get', return_value=resp):
         yield [MOCK_SERVER]
 
 

--- a/kishu/tests/test_runtime.py
+++ b/kishu/tests/test_runtime.py
@@ -45,7 +45,7 @@ def test_iter_maybe_running_servers_bad_json():
 
 
 def test_get_sessions_raises_exception():
-    with patch('kishu.runtime.urllib.request.urlopen', side_effect=Exception):
+    with patch('kishu.runtime.requests.get', side_effect=Exception):
         sessions = JupyterRuntimeEnv.get_sessions({"url": "http://localhost:8888/", "token": "token_value"})
     assert not sessions
 


### PR DESCRIPTION
- Nested API call needs cookies (for authentication)
- Pass cookies from handler to Kishu's Jupyter runtime context
- Remove dependency to API call in remote `init_kishu` since it knows the path already