### PR TITLE
Deprecate kishu load string for tests

### DIFF
--- a/kishu/tests/helpers/nbexec.py
+++ b/kishu/tests/helpers/nbexec.py
@@ -160,9 +160,6 @@ class NotebookRunner:
         kishu_checkout_code = get_kishu_checkout_str(cell_num_to_restore)
         notebook.cells.append(new_code_cell(source=kishu_checkout_code))
 
-        # Insert kishu log string
-        # notebook.cells.append(new_code_cell("stuff = _kishu.log()"))
-
         # Insert dump session code at end of notebook after kishu checkout.
         dumpsession_code_end = get_dump_namespace_str(self.pickle_file + ".end")
         notebook.cells.append(new_code_cell(source=dumpsession_code_end))


### PR DESCRIPTION
Deprecate `kishu` load string for tests. The original error from switching from `kishu load` to `kishu init` was due to a difference in commit ID prefix (`load` had IDs following `0:x` while `init`'s followed `1:x`).