### PR TITLE
Instantiate Kishu branch and tag as storages

### DIFF
--- a/kishu/kishu/storage/tag.py
+++ b/kishu/kishu/storage/tag.py
@@ -20,27 +20,24 @@ class TagRow:
 
 class KishuTag:
 
-    @staticmethod
-    def init_database(notebook_id: str):
-        dbfile = KishuPath.database_path(notebook_id)
-        con = sqlite3.connect(dbfile)
+    def __init__(self, notebook_id: str):
+        self.database_path = KishuPath.database_path(notebook_id)
+
+    def init_database(self):
+        con = sqlite3.connect(self.database_path)
         cur = con.cursor()
         cur.execute(f'create table if not exists {TAG_TABLE} (tag_name text primary key, commit_id text, message text)')
         con.commit()
 
-    @staticmethod
-    def upsert_tag(notebook_id: str, tag: TagRow) -> None:
-        dbfile = KishuPath.database_path(notebook_id)
-        con = sqlite3.connect(dbfile)
+    def upsert_tag(self, tag: TagRow) -> None:
+        con = sqlite3.connect(self.database_path)
         cur = con.cursor()
         query = f"insert or replace into {TAG_TABLE} values (?, ?, ?)"
         cur.execute(query, (tag.tag_name, tag.commit_id, tag.message))
         con.commit()
 
-    @staticmethod
-    def list_tag(notebook_id: str) -> List[TagRow]:
-        dbfile = KishuPath.database_path(notebook_id)
-        con = sqlite3.connect(dbfile)
+    def list_tag(self, ) -> List[TagRow]:
+        con = sqlite3.connect(self.database_path)
         cur = con.cursor()
         query = f"select tag_name, commit_id, message from {TAG_TABLE}"
         try:
@@ -55,10 +52,8 @@ class KishuTag:
         finally:
             con.close()
 
-    @staticmethod
-    def tags_for_commit(notebook_id: str, commit_id: str) -> List[TagRow]:
-        dbfile = KishuPath.database_path(notebook_id)
-        con = sqlite3.connect(dbfile)
+    def tags_for_commit(self, commit_id: str) -> List[TagRow]:
+        con = sqlite3.connect(self.database_path)
         cur = con.cursor()
         query = f"select tag_name, commit_id, message from {TAG_TABLE} where commit_id = ?"
         try:
@@ -73,10 +68,8 @@ class KishuTag:
         finally:
             con.close()
 
-    @staticmethod
-    def tags_for_many_commits(notebook_id: str, commit_ids: List[str]) -> Dict[str, List[TagRow]]:
-        dbfile = KishuPath.database_path(notebook_id)
-        con = sqlite3.connect(dbfile)
+    def tags_for_many_commits(self, commit_ids: List[str]) -> Dict[str, List[TagRow]]:
+        con = sqlite3.connect(self.database_path)
         cur = con.cursor()
         query = "select tag_name, commit_id, message from {} where commit_id in ({})".format(
             TAG_TABLE,

--- a/kishu/tests/test_cli.py
+++ b/kishu/tests/test_cli.py
@@ -93,7 +93,7 @@ class TestKishuApp:
             " Notebook key: .*."
             " Kernel Id: .*"
         )
-        assert re.search(pattern, init_result).group(0) is not None
+        assert re.search(pattern, init_result) is not None, f"init_result: {init_result}"
 
     def test_log_empty(self, runner, tmp_kishu_path):
         result = runner.invoke(kishu_app, ["log", "NON_EXISTENT_NOTEBOOK_ID"])

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -207,7 +207,7 @@ class TestKishuCommand:
 
         rename_branch_result = KishuCommand.rename_branch(
             notebook_key, branch_1, "new_branch")
-        head = KishuBranch.get_head(notebook_key)
+        head = KishuBranch(notebook_key).get_head()
         assert rename_branch_result.status == "ok"
         assert head.branch_name == "new_branch"
 
@@ -227,11 +227,12 @@ class TestKishuCommand:
         assert rename_branch_result.status == "error"
 
     def test_auto_detach_commit_branch(self, kishu_jupyter):
-        KishuBranch.update_head(kishu_jupyter._notebook_id.key(), branch_name=None, commit_id="0:1", is_detach=True)
+        kishu_branch = KishuBranch(kishu_jupyter._notebook_id.key())
+        kishu_branch.update_head(branch_name=None, commit_id="0:1", is_detach=True)
         commit = CommitEntry(kind=CommitEntryKind.manual, execution_count=1, raw_cell="x = 1")
         commit_id = kishu_jupyter.commit(commit)
 
-        head = KishuBranch.get_head(kishu_jupyter._notebook_id.key())
+        head = kishu_branch.get_head()
         assert head.branch_name is not None
         assert head.branch_name.startswith("auto_")
         assert head.commit_id == commit_id


### PR DESCRIPTION
- Instantiate `KishuBranch` and `KishuTag`, following `KishuCommit` pattern
- No need to supply notebook ID at every branch and tag method