### PR TITLE
Run tests in parallel + re-enable Python 3.9 and 3.10 tests

### DIFF
--- a/.github/workflows/kishu.yml
+++ b/.github/workflows/kishu.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # python-version: ["3.8", "3.9", "3.10"]
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -33,13 +32,8 @@ jobs:
       run: |
         cd kishu
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        python -m pip install .
+        python -m pip install .[dev]
         python -c "import kishu, kishu.cli, kishu.backend, kishu.commands"
-    - name: Install development dependencies
-      run: |
-        cd kishu
-        if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
     - name: Lint with flake8
       run: |
         cd kishu
@@ -53,10 +47,10 @@ jobs:
       run: |
         cd kishu
         if [ "${{ matrix.python-version }}" == "3.8" ]; then
-          pytest -vv --cov=kishu/ --cov-report=xml;
+          pytest -vv --cov=kishu/ --cov-report=xml -n 2;
           head coverage.xml
         else
-          pytest -vv
+          pytest -vv -n 2
         fi
     - name: Upload coverage reports to Codecov
       if:  ${{ matrix.python-version == '3.8' && steps.extract_branch.outputs.branch == 'main' }}

--- a/kishu/dev-requirements.txt
+++ b/kishu/dev-requirements.txt
@@ -6,6 +6,7 @@ flake8
 mypy
 pytest
 pytest-cov
+pytest-xdist
 
 # Test cases
 matplotlib

--- a/kishu/pyproject.toml
+++ b/kishu/pyproject.toml
@@ -71,6 +71,7 @@ dev = [  # README: Keep in sync with dev-requirements.txt
     "mypy",
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
 
     # Test cases
     "matplotlib",

--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -34,7 +34,7 @@ def set_test_mode() -> Generator[None, None, None]:
 
 
 # Use this fixture to mount Kishu in a temporary directory.
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def tmp_kishu_path(tmp_path: Path) -> Generator[Type[KishuPath], None, None]:
     original_root = os.environ.get(ENV_KISHU_PATH_ROOT, None)
     os.environ[ENV_KISHU_PATH_ROOT] = str(tmp_path)

--- a/kishu/tests/test_backend.py
+++ b/kishu/tests/test_backend.py
@@ -12,7 +12,7 @@ def test_health(backend_client):
     assert data["status"] == "ok"
 
 
-def test_list_empty(backend_client, tmp_kishu_path):
+def test_list_empty(backend_client):
     result = backend_client.get("/list")
     assert result.status_code == 200
     assert ListResult.from_json(result.data) == ListResult(sessions=[])
@@ -22,7 +22,7 @@ def test_list_empty(backend_client, tmp_kishu_path):
     assert ListResult.from_json(result.data) == ListResult(sessions=[])
 
 
-def test_log_empty(backend_client, tmp_kishu_path):
+def test_log_empty(backend_client):
     result = backend_client.get("/log/NON_EXISTENT_NOTEBOOK_ID")
     assert result.status_code == 200
     assert LogResult.from_json(result.data) == LogResult(

--- a/kishu/tests/test_cli.py
+++ b/kishu/tests/test_cli.py
@@ -42,7 +42,7 @@ class TestKishuApp:
         assert result.exit_code == 0
         assert f"{__app_name__} v{__version__}\n" in result.stdout
 
-    def test_list_empty(self, runner, tmp_kishu_path):
+    def test_list_empty(self, runner):
         result = runner.invoke(kishu_app, ["list"])
         assert result.exit_code == 0
         assert ListResult.from_json(result.stdout) == ListResult(sessions=[])
@@ -55,55 +55,53 @@ class TestKishuApp:
         assert result.exit_code == 0
         assert ListResult.from_json(result.stdout) == ListResult(sessions=[])
 
-    def test_init_empty(self, runner, tmp_kishu_path):
+    def test_init_empty(self, runner):
         result = runner.invoke(kishu_app, ["init", "non_existent_notebook.ipynb"])
         assert result.exit_code == 0
         init_result = result.stdout
         assert init_result == "Notebook kernel not found. Make sure Jupyter kernel is running for requested notebook\n"
 
-    def test_detach_empty(self, runner, tmp_kishu_path):
+    def test_detach_empty(self, runner):
         result = runner.invoke(kishu_app, ["detach", "non_existent_notebook.ipynb"])
         assert result.exit_code == 0
         detach_result = result.stdout
         assert detach_result == "Notebook kernel not found. Make sure Jupyter kernel is running for requested notebook\n"
 
-    def test_detach_simple(self, runner, tmp_kishu_path, nb_simple_path, jupyter_server):
-        nb_path = nb_simple_path
-        with jupyter_server.start_session(nb_path):
-            init_result_raw = runner.invoke(kishu_app, ["init", str(nb_path)])
+    def test_detach_simple(self, runner, nb_simple_path, jupyter_server):
+        with jupyter_server.start_session(nb_simple_path):
+            init_result_raw = runner.invoke(kishu_app, ["init", str(nb_simple_path)])
             assert init_result_raw.exit_code == 0
-            detach_result_raw = runner.invoke(kishu_app, ["detach", str(nb_path)])
+            detach_result_raw = runner.invoke(kishu_app, ["detach", str(nb_simple_path)])
             assert detach_result_raw.exit_code == 0
             detach_result = detach_result_raw.stdout
-            assert detach_result == f"Successfully detached notebook {nb_path}\n"
+            assert detach_result == f"Successfully detached notebook {nb_simple_path}\n"
 
-    def test_init_no_jupyter_server(self, runner, tmp_kishu_path):
+    def test_init_no_jupyter_server(self, runner):
         result = runner.invoke(kishu_app, ["init", "non_existent_notebook.ipynb"])
         assert result.exit_code == 0
         detach_result = result.stdout
         assert detach_result == "Notebook kernel not found. Make sure Jupyter kernel is running for requested notebook\n"
 
-    def test_init_simple(self, runner, tmp_kishu_path, nb_simple_path, jupyter_server):
-        nb_path = nb_simple_path
-        with jupyter_server.start_session(nb_path):
-            result = runner.invoke(kishu_app, ["init", str(nb_path)])
+    def test_init_simple(self, runner, nb_simple_path, jupyter_server):
+        with jupyter_server.start_session(nb_simple_path):
+            result = runner.invoke(kishu_app, ["init", str(nb_simple_path)])
             assert result.exit_code == 0
 
             init_result = result.stdout
             pattern = (
-                f"Successfully initialized notebook {re.escape(str(nb_path))}."
+                f"Successfully initialized notebook {re.escape(str(nb_simple_path))}."
                 " Notebook key: .*."
                 " Kernel Id: .*"
             )
             assert re.search(pattern, init_result) is not None, f"init_result: {init_result}"
 
-    def test_checkout_no_jupyter_server(self, runner, nb_simple_path, tmp_kishu_path):
+    def test_checkout_no_jupyter_server(self, runner, nb_simple_path):
         result = runner.invoke(kishu_app, ["checkout", str(nb_simple_path), "abc123"])
         assert result.exit_code == 0
         checkout_result = result.stdout
         assert checkout_result == "Notebook kernel not found. Make sure Jupyter kernel is running for requested notebook\n"
 
-    def test_checkout_simple(self, runner, nb_simple_path, jupyter_server, tmp_kishu_path):
+    def test_checkout_simple(self, runner, nb_simple_path, jupyter_server):
         # Start the notebook session.
         contents = JupyterRuntimeEnv.read_notebook_cell_source(nb_simple_path)
         with jupyter_server.start_session(nb_simple_path) as notebook_session:
@@ -119,7 +117,7 @@ class TestKishuApp:
         checkout_result = result.stdout
         assert checkout_result == "Checkout 1:2 in detach mode.\n"
 
-    def test_checkout_reattach(self, runner, nb_simple_path, jupyter_server, tmp_kishu_path):
+    def test_checkout_reattach(self, runner, nb_simple_path, jupyter_server):
         # Start the notebook session.
         notebook_path = nb_simple_path
         contents = JupyterRuntimeEnv.read_notebook_cell_source(notebook_path)
@@ -138,20 +136,18 @@ class TestKishuApp:
             result = runner.invoke(kishu_app, ["checkout", str(nb_simple_path), "1:2"])
 
         assert result.exit_code == 0
-        checkout_result = result.stdout
-        segments = checkout_result.split("\n")
-        assert len(segments) == 4 and segments[-1] == ""
-        reattach_message = "Notebook instrumentation was present but not initialized, so attempting to re-initialize it"
-        assert segments[0] == reattach_message
+        result_lines = result.stdout.split("\n")
+        assert len(result_lines) == 4 and result_lines[-1] == ""
+        assert result_lines[0] == "Notebook instrumentation was present but not initialized, so attempting to re-initialize it"
         pattern = (
             f"Successfully reattached notebook {re.escape(str(nb_simple_path))}."
             " Notebook key: .*."
             " Kernel Id: .*"
         )
-        assert re.search(pattern, segments[1]) is not None
-        assert segments[2] == "Checkout 1:2 in detach mode."
+        assert re.search(pattern, result_lines[1]) is not None
+        assert result_lines[2] == "Checkout 1:2 in detach mode."
 
-    def test_checkout_no_metadata(self, runner, tmp_kishu_path, nb_simple_path, jupyter_server):
+    def test_checkout_no_metadata(self, runner, nb_simple_path, jupyter_server):
         with jupyter_server.start_session(nb_simple_path):
             result = runner.invoke(kishu_app, ["checkout", str(nb_simple_path), "abcd123"])
             assert result.exit_code == 0
@@ -162,13 +158,13 @@ class TestKishuApp:
             )
             assert checkout_result == no_metadata_output
 
-    def test_log_empty(self, runner, tmp_kishu_path):
+    def test_log_empty(self, runner):
         result = runner.invoke(kishu_app, ["log", "NON_EXISTENT_NOTEBOOK_ID"])
         assert result.exit_code == 1
         assert isinstance(result.exception, NotNotebookPathOrKey)
         assert "NON_EXISTENT_NOTEBOOK_ID" in str(result.exception)
 
-    def test_create_branch(self, runner, tmp_kishu_path, notebook_key, basic_execution_ids):
+    def test_create_branch(self, runner, notebook_key, basic_execution_ids):
         result = runner.invoke(kishu_app, ["branch", notebook_key, "-c", "new_branch"])
         assert result.exit_code == 0
         branch_result = BranchResult.from_json(result.stdout)
@@ -179,7 +175,7 @@ class TestKishuApp:
             head=branch_result.head,  # Not tested
         )
 
-    def test_delete_non_checked_out_branch(self, runner, tmp_kishu_path, notebook_key, basic_execution_ids):
+    def test_delete_non_checked_out_branch(self, runner, notebook_key, basic_execution_ids):
         runner.invoke(kishu_app, ["branch", notebook_key, "-c", "branch_to_keep", basic_execution_ids[-2]])
         runner.invoke(kishu_app, ["branch", notebook_key, "-c", "branch_to_delete", basic_execution_ids[-1]])
         result = runner.invoke(kishu_app, ["checkout", notebook_key, "branch_to_keep"])
@@ -193,7 +189,7 @@ class TestKishuApp:
             message="Branch branch_to_delete deleted.",
         )
 
-    def test_delete_checked_out_branch(self, runner, tmp_kishu_path, notebook_key, basic_execution_ids):
+    def test_delete_checked_out_branch(self, runner, notebook_key, basic_execution_ids):
         runner.invoke(kishu_app, ["branch", notebook_key, "-c", "branch_to_delete"])  # Checked out branch
 
         result = runner.invoke(kishu_app, ["branch", notebook_key, "-d", "branch_to_delete"])
@@ -204,7 +200,7 @@ class TestKishuApp:
             message="Cannot delete the currently checked-out branch.",
         )
 
-    def test_delete_nonexisting_branch(self, runner, tmp_kishu_path, kishu_jupyter):
+    def test_delete_nonexisting_branch(self, runner, kishu_jupyter):
         result = runner.invoke(kishu_app, ["branch", kishu_jupyter._notebook_id.key(), "-d", "NON_EXISTENT_BRANCH"])
         assert result.exit_code == 0
         delete_branch_result = DeleteBranchResult.from_json(result.stdout)
@@ -213,7 +209,7 @@ class TestKishuApp:
             message="The provided branch 'NON_EXISTENT_BRANCH' does not exist.",
         )
 
-    def test_rename_branch(self, runner, tmp_kishu_path, notebook_key, basic_execution_ids):
+    def test_rename_branch(self, runner, notebook_key, basic_execution_ids):
         runner.invoke(kishu_app, ["branch", notebook_key, "-c", "old_name"])
         result = runner.invoke(kishu_app, ["branch", notebook_key, "-m", "old_name", "new_name"])
         assert result.exit_code == 0
@@ -224,7 +220,7 @@ class TestKishuApp:
             message="Branch renamed from old_name to new_name.",
         )
 
-    def test_rename_non_existing_branch(self, runner, tmp_kishu_path, kishu_jupyter):
+    def test_rename_non_existing_branch(self, runner, kishu_jupyter):
         result = runner.invoke(
             kishu_app, ["branch", kishu_jupyter._notebook_id.key(), "-m", "NON_EXISTENT_BRANCH", "new_name"])
         assert result.exit_code == 0
@@ -235,7 +231,7 @@ class TestKishuApp:
             message="The provided branch 'NON_EXISTENT_BRANCH' does not exist.",
         )
 
-    def test_rename_to_existing_branch(self, runner, tmp_kishu_path, notebook_key, basic_execution_ids):
+    def test_rename_to_existing_branch(self, runner, notebook_key, basic_execution_ids):
         runner.invoke(kishu_app, ["branch", notebook_key, "-c", "old_name"])
         runner.invoke(kishu_app, ["branch", notebook_key, "-c", "existing_name"])
         result = runner.invoke(kishu_app, ["branch", notebook_key, "-m", "old_name", "existing_name"])
@@ -247,7 +243,7 @@ class TestKishuApp:
             message="The provided new branch name already exists.",
         )
 
-    def test_create_tag_head(self, runner, tmp_kishu_path, kishu_jupyter, basic_execution_ids):
+    def test_create_tag_head(self, runner, kishu_jupyter, basic_execution_ids):
         result = runner.invoke(kishu_app, ["tag", kishu_jupyter._notebook_id.key(), "tag_1"])
         assert result.exit_code == 0
         tag_result = TagResult.from_json(result.stdout)
@@ -258,7 +254,7 @@ class TestKishuApp:
             message="",
         )
 
-    def test_create_tag_specific(self, runner, tmp_kishu_path, kishu_jupyter, basic_execution_ids):
+    def test_create_tag_specific(self, runner, kishu_jupyter, basic_execution_ids):
         result = runner.invoke(kishu_app, ["tag", kishu_jupyter._notebook_id.key(), "tag_1", basic_execution_ids[1]])
         assert result.exit_code == 0
         tag_result = TagResult.from_json(result.stdout)
@@ -269,7 +265,7 @@ class TestKishuApp:
             message="",
         )
 
-    def test_create_tag_message(self, runner, tmp_kishu_path, kishu_jupyter, basic_execution_ids):
+    def test_create_tag_message(self, runner, kishu_jupyter, basic_execution_ids):
         tag_message = "Tagging for test_create_tag_message"
         result = runner.invoke(kishu_app, ["tag", kishu_jupyter._notebook_id.key(), "tag_1", "-m", tag_message])
         assert result.exit_code == 0
@@ -281,7 +277,7 @@ class TestKishuApp:
             message=tag_message,
         )
 
-    def test_tag_list(self, runner, tmp_kishu_path, kishu_jupyter, basic_execution_ids):
+    def test_tag_list(self, runner, kishu_jupyter, basic_execution_ids):
         result = runner.invoke(kishu_app, ["tag", kishu_jupyter._notebook_id.key(), "tag_1"])
         assert result.exit_code == 0
         result = runner.invoke(kishu_app, ["tag", kishu_jupyter._notebook_id.key(), "tag_2"])
@@ -295,7 +291,7 @@ class TestKishuApp:
         assert len(list_tag_result.tags) == 3
         assert set(tag.tag_name for tag in list_tag_result.tags) == {"tag_1", "tag_2", "tag_3"}
 
-    def test_delete_tag(self, runner, tmp_kishu_path, kishu_jupyter, basic_execution_ids):
+    def test_delete_tag(self, runner, kishu_jupyter, basic_execution_ids):
         result = runner.invoke(kishu_app, ["tag", kishu_jupyter._notebook_id.key(), "tag_1"])
         assert result.exit_code == 0
 
@@ -307,7 +303,7 @@ class TestKishuApp:
             message="Tag tag_1 deleted.",
         )
 
-    def test_delete_tag_nonexisting(self, runner, tmp_kishu_path, kishu_jupyter, basic_execution_ids):
+    def test_delete_tag_nonexisting(self, runner, kishu_jupyter, basic_execution_ids):
         result = runner.invoke(kishu_app, ["tag", kishu_jupyter._notebook_id.key(), "tag_1"])
         assert result.exit_code == 0
 
@@ -323,8 +319,13 @@ class TestKishuApp:
                              [[],
                               ["simple.ipynb"],
                               ["simple.ipynb", "numpy.ipynb"]])
-    def test_list_with_server(self, runner, tmp_kishu_path, tmp_nb_path,
-                              jupyter_server, notebook_names: List[str]):
+    def test_list_with_server(
+        self,
+        runner,
+        tmp_nb_path,
+        jupyter_server,
+        notebook_names: List[str],
+    ):
         # Start sessions and run kishu init cell in each of these sessions.
         for notebook_name in notebook_names:
             with jupyter_server.start_session(tmp_nb_path(notebook_name), persist=True) as notebook_session:
@@ -341,8 +342,13 @@ class TestKishuApp:
         kishu_list_notebook_names = [Path(session["notebook_path"]).name for session in list_result["sessions"]]
         assert set(notebook_names) == set(kishu_list_notebook_names)
 
-    def test_list_with_server_no_init(self, runner, tmp_kishu_path, tmp_nb_path,
-                                      jupyter_server, notebook_name="simple.ipynb"):
+    def test_list_with_server_no_init(
+        self,
+        runner,
+        tmp_nb_path,
+        jupyter_server,
+        notebook_name="simple.ipynb",
+    ):
         with jupyter_server.start_session(tmp_nb_path(notebook_name)):
             # Kishu should not be able to see this session as "kishu init" was not executed.
             result = runner.invoke(kishu_app, ["list"])

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -361,7 +361,6 @@ class TestKishuCommand:
                               ["simple.ipynb", "numpy.ipynb"]])
     def test_list_alive_sessions(
         self,
-        tmp_kishu_path,
         tmp_nb_path,
         jupyter_server,
         notebook_names: List[str],
@@ -382,7 +381,6 @@ class TestKishuCommand:
 
     def test_list_alive_session_no_init(
         self,
-        tmp_kishu_path,
         tmp_nb_path,
         jupyter_server,
     ):
@@ -400,7 +398,6 @@ class TestKishuCommand:
     )
     def test_end_to_end_checkout(
         self,
-        tmp_kishu_path,
         tmp_nb_path,
         jupyter_server,
         notebook_name: str,
@@ -449,7 +446,6 @@ class TestKishuCommand:
 
     def test_checkout_reattach(
         self,
-        tmp_kishu_path,
         tmp_nb_path,
         jupyter_server,
     ):
@@ -502,7 +498,6 @@ class TestKishuCommand:
 
     def test_init_in_nonempty_session(
         self,
-        tmp_kishu_path,
         tmp_nb_path,
         jupyter_server,
     ):

--- a/kishu/tests/test_jupyterint.py
+++ b/kishu/tests/test_jupyterint.py
@@ -2,7 +2,6 @@ import dill
 import nbformat
 import pytest
 
-from pathlib import Path
 from typing import List
 
 from kishu.jupyterint import KishuForJupyter
@@ -48,13 +47,13 @@ class TestOnNotebookRunner:
 
     # Modify the test_checkout to use the new fixture.
     @pytest.mark.parametrize("set_notebook_path_env", ["test_jupyter_checkout.ipynb"], indirect=True)
-    def test_checkout(self, tmp_kishu_path: Path, set_notebook_path_env):
+    def test_checkout(self, set_notebook_path_env):
         notebook = NotebookRunner(set_notebook_path_env)
         output = notebook.execute([])
         assert output['a'] == 1
 
     @pytest.mark.parametrize("set_notebook_path_env", ["test_init_kishu.ipynb"], indirect=True)
-    def test_reattatchment(self, tmp_kishu_path: Path, set_notebook_path_env):
+    def test_reattatchment(self, set_notebook_path_env):
         notebook = NotebookRunner(set_notebook_path_env)
         output = notebook.execute([])
         assert output['a'] == 1
@@ -80,7 +79,7 @@ class TestOnNotebookRunner:
         ],
         indirect=["set_notebook_path_env"]
     )
-    def test_full_checkout(self, tmp_kishu_path: Path, set_notebook_path_env, cell_num_to_restore: int):
+    def test_full_checkout(self, set_notebook_path_env, cell_num_to_restore: int):
         """
         Tests checkout correctness by comparing namespace contents at cell_num_to_restore in the middle of a notebook,
         and namespace contents after checking out cell_num_to_restore completely executing the notebook.
@@ -97,7 +96,7 @@ class TestOnNotebookRunner:
             assert dill.dumps(namespace_before_checkout[key]) == dill.dumps(namespace_after_checkout[key])
 
     @pytest.mark.parametrize("set_notebook_path_env", ["test_detach_kishu.ipynb"], indirect=True)
-    def test_detachment_valid(self, tmp_kishu_path: Path, set_notebook_path_env):
+    def test_detachment_valid(self, set_notebook_path_env):
         notebook = NotebookRunner(set_notebook_path_env)
         notebook.execute([])
         with open(set_notebook_path_env, "r") as nb_file:
@@ -105,7 +104,7 @@ class TestOnNotebookRunner:
             assert "kishu" not in nb.metadata
 
     @pytest.mark.parametrize("set_notebook_path_env", ["test_detach_kishu_no_init.ipynb"], indirect=True)
-    def test_detachment_fails_gracefully(self, tmp_kishu_path: Path, set_notebook_path_env):
+    def test_detachment_fails_gracefully(self, set_notebook_path_env):
         notebook = NotebookRunner(set_notebook_path_env)
         notebook.execute([])
         assert True  # making sure no errors were thrown


### PR DESCRIPTION
- Faster test time (hopefully lower GitHub Action minutes)
- Re-enable Python 3.9 and 3.10 (#188)