### PR TITLE
Standardize storage method patterns + rename commit table

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -236,7 +236,7 @@ class KishuForJupyter:
     def __init__(self, notebook_id: NotebookId, ip: Optional[InteractiveShell] = None) -> None:
         # Kishu info and storages.
         self._notebook_id = notebook_id
-        self._kishu_commit = KishuCommit(self.database_path())
+        self._kishu_commit = KishuCommit(self._notebook_id.key())
         self._kishu_checkpoint = KishuCheckpoint(self.database_path())
         self._kishu_branch = KishuBranch(self._notebook_id.key())
         self._kishu_tag = KishuTag(self._notebook_id.key())
@@ -323,7 +323,7 @@ class KishuForJupyter:
         # Retrieve checkout plan.
         database_path = self.database_path()
         commit_id = KishuForJupyter.disambiguate_commit(self._notebook_id.key(), commit_id)
-        commit_entry = self._kishu_commit.get_log_item(commit_id)
+        commit_entry = self._kishu_commit.get_commit(commit_id)
         if commit_entry.restore_plan is None:
             raise ValueError("No restore plan found for commit_id = {}".format(commit_id))
 
@@ -473,8 +473,7 @@ class KishuForJupyter:
 
     @staticmethod
     def disambiguate_commit(notebook_key: str, commit_id: str) -> str:
-        database_path = KishuPath.database_path(notebook_key)
-        kishu_commit = KishuCommit(database_path)
+        kishu_commit = KishuCommit(notebook_key)
         possible_commit_ids = kishu_commit.keys_like(commit_id)
         if len(possible_commit_ids) == 0:
             raise ValueError(f"No commit with ID {repr(commit_id)}")
@@ -515,7 +514,7 @@ class KishuForJupyter:
         entry.checkpoint_runtime_s = checkpoint_runtime_s
 
         # Update other structures.
-        self._kishu_commit.store_log_item(entry)
+        self._kishu_commit.store_commit(entry)
         self._kishu_graph.step(entry.commit_id)
         self._step_branch(entry.commit_id)
 

--- a/kishu/kishu/notebook_id.py
+++ b/kishu/kishu/notebook_id.py
@@ -60,7 +60,11 @@ class NotebookId:
         # Try parsing as path, if exists.
         path = Path(path_or_key)
         if path.exists():
-            return NotebookId.parse_key_from_path(path)
+            try:
+                return NotebookId.parse_key_from_path(path)
+            except (nbformat.reader.NotJSONError, UnicodeDecodeError):
+                # Ignore non-notebook file.
+                pass
 
         # Notebook path does not exist, try parsing as key.
         key = path_or_key

--- a/kishu/kishu/storage/branch.py
+++ b/kishu/kishu/storage/branch.py
@@ -162,7 +162,7 @@ class KishuBranch:
         head = self.get_head()
         if branch_name == head.branch_name:
             raise BranchConflictError("Cannot delete the currently checked-out branch.")
-        if not KishuBranch.contains_branch(cur, branch_name):
+        if not KishuBranch._contains_branch(cur, branch_name):
             raise BranchNotFoundError(branch_name)
 
         query = f"delete from {BRANCH_TABLE} where branch_name = ?"
@@ -173,9 +173,9 @@ class KishuBranch:
         con = sqlite3.connect(self.database_path)
         cur = con.cursor()
 
-        if not KishuBranch.contains_branch(cur, old_name):
+        if not KishuBranch._contains_branch(cur, old_name):
             raise BranchNotFoundError(old_name)
-        if KishuBranch.contains_branch(cur, new_name):
+        if KishuBranch._contains_branch(cur, new_name):
             raise BranchConflictError("The provided new branch name already exists.")
 
         query = f"update {BRANCH_TABLE} set branch_name = ? where branch_name = ?"
@@ -188,7 +188,7 @@ class KishuBranch:
             self.update_head(branch_name=new_name)
 
     @staticmethod
-    def contains_branch(cur: sqlite3.Cursor, branch_name: str) -> bool:
+    def _contains_branch(cur: sqlite3.Cursor, branch_name: str) -> bool:
         query = f"select count(*) from {BRANCH_TABLE} where branch_name = ?"
         cur.execute(query, (branch_name,))
         return cur.fetchone()[0] == 1

--- a/kishu/kishu/storage/checkpoint.py
+++ b/kishu/kishu/storage/checkpoint.py
@@ -8,26 +8,17 @@ CHECKPOINT_TABLE = 'checkpoint'
 
 
 class KishuCheckpoint:
-    def __init__(self, dbfile: str):
-        self.dbfile = dbfile
-
-    def _save_into_table(self, table_name: str, commit_id: str, data: bytes) -> None:
-        con = sqlite3.connect(self.dbfile)
-        cur = con.cursor()
-        cur.execute(
-            "insert into {} values (?, ?)".format(table_name),
-            (commit_id, memoryview(data))
-        )
-        con.commit()
+    def __init__(self, database_path: str):
+        self.database_path = database_path
 
     def init_database(self):
-        con = sqlite3.connect(self.dbfile)
+        con = sqlite3.connect(self.database_path)
         cur = con.cursor()
         cur.execute(f'create table if not exists {CHECKPOINT_TABLE} (commit_id text primary key, data blob)')
         con.commit()
 
     def get_checkpoint(self, commit_id: str) -> bytes:
-        con = sqlite3.connect(self.dbfile)
+        con = sqlite3.connect(self.database_path)
         cur = con.cursor()
         cur.execute(
             f"select data from {CHECKPOINT_TABLE} where commit_id = ?",
@@ -39,7 +30,7 @@ class KishuCheckpoint:
         return result
 
     def store_checkpoint(self, commit_id: str, data: bytes) -> None:
-        con = sqlite3.connect(self.dbfile)
+        con = sqlite3.connect(self.database_path)
         cur = con.cursor()
         cur.execute(
             f"insert into {CHECKPOINT_TABLE} values (?, ?)",


### PR DESCRIPTION
- Method naming
- Rename commit table from `history` to `commit_entry`
- Remove unnecessary methods
- Fix disambiguation bug

To rename existing, edit `KishuCommit` and run any Kishu cli on the same notebook key/path
```python
class KishuCommit:
    def __init__(self, notebook_id: str):
        self.database_path = KishuPath.database_path(notebook_id)
        con = sqlite3.connect(self.database_path)
        cur = con.cursor()
        cur.execute(f'ALTER TABLE history RENAME TO {COMMIT_ENTRY_TABLE};')
        con.commit()
```