### PR TITLE
Auto-refresh notebook frontend on init and checkout

### DIFF
--- a/jupyterlab_kishu/src/index.ts
+++ b/jupyterlab_kishu/src/index.ts
@@ -241,7 +241,7 @@ function installCommands(
         } else {
           notify_manager.update({
             id: notify_id,
-            message: trans.__(`Kishu checkout to ${commit_id} succeeded!\nPlease refresh this page.`),
+            message: trans.__(`Kishu checkout to ${commit_id} succeeded!`),
             type: 'success',
             autoClose: 3000,
           });


### PR DESCRIPTION
- On init, this reflects the notebook metadata change and helps reducing prompts around unmodified changes
- On checkout, this reload the notebook display without refreshing browser.

Tested on JupyterLab and Notebook 7