### PR TITLE
Save notebook before auto-refresh

### DIFF
--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 import shutil
 
+from IPython.core.interactiveshell import InteractiveShell
 from pathlib import Path, PurePath
 from typing import Callable, Generator, List, Optional, Type
 from unittest.mock import patch
@@ -181,7 +182,8 @@ def notebook_key() -> Generator[str, None, None]:
 
 @pytest.fixture()
 def kishu_jupyter(tmp_kishu_path, notebook_key, set_notebook_path_env) -> Generator[KishuForJupyter, None, None]:
-    kishu_jupyter = KishuForJupyter(notebook_id=NotebookId.from_enclosing_with_key(notebook_key))
+    ip = InteractiveShell()
+    kishu_jupyter = KishuForJupyter(notebook_id=NotebookId.from_enclosing_with_key(notebook_key), ip=ip)
     yield kishu_jupyter
 
 

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -129,6 +129,12 @@ class TestKishuCommand:
             commit_id="0:3",
             execution_count=3,
             raw_cell="y = x + 1",
+            executed_cells=[  # TODO: Missing due to missing IPython kernel.
+                "",
+                # "x = 1",
+                # "y = 2",
+                # "y = x + 1",
+            ],
             message=status_result.commit_entry.message,  # Not tested,
             timestamp=status_result.commit_entry.timestamp,  # Not tested
             ahg_string=status_result.commit_entry.ahg_string,  # Not tested
@@ -347,6 +353,7 @@ class TestKishuCommand:
                 var_version=fe_commit_result.commit.var_version,  # Not tested
             ),
             executed_cells=[  # TODO: Missing due to missing IPython kernel.
+                "",
                 # "x = 1",
                 # "y = 2",
                 # "y = x + 1",


### PR DESCRIPTION
#248
- Refactor `jupyterint.py`
- Save notebook from Jupyter frontend before writing notebook metadata 
- Enforce `InteractiveShell` requirement