### PR TITLE
Edit existing commit message

### DIFF
--- a/kishu/kishu/cli.py
+++ b/kishu/kishu/cli.py
@@ -222,11 +222,28 @@ def commit(
         help="Commit message.",
         show_default=False,
     ),
+    edit_branch_or_commit_id: str = typer.Option(
+        None,
+        "-e",
+        "--edit-branch-name",
+        "--edit_branch_name",
+        "--edit-commit-id",
+        "--edit_commit_id",
+        help="Branch name or commit ID to edit.",
+        show_default=False,
+    ),
 ) -> None:
     """
-    Checkout a notebook to a commit.
+    Create or edit a Kishu commit.
     """
-    print_commit_message(KishuCommand.commit(notebook_path_or_key, message=message))
+    if edit_branch_or_commit_id:
+        print(into_json(KishuCommand.edit_commit(
+            notebook_path_or_key,
+            edit_branch_or_commit_id,
+            message=message,
+        )))
+    else:
+        print_commit_message(KishuCommand.commit(notebook_path_or_key, message=message))
 
 
 @kishu_app.command()

--- a/kishu/kishu/storage/commit.py
+++ b/kishu/kishu/storage/commit.py
@@ -106,6 +106,16 @@ class KishuCommit:
         )
         con.commit()
 
+    def update_commit(self, commit_entry: CommitEntry) -> None:
+        commit_entry_dill = dill.dumps(commit_entry)
+        con = sqlite3.connect(self.database_path)
+        cur = con.cursor()
+        cur.execute(
+            f"update {COMMIT_ENTRY_TABLE} set data = ? where commit_id = ?",
+            (memoryview(commit_entry_dill), commit_entry.commit_id)
+        )
+        con.commit()
+
     def get_commit(self, commit_id: str) -> CommitEntry:
         con = sqlite3.connect(self.database_path)
         cur = con.cursor()


### PR DESCRIPTION
- Allow editing of an existing commit by its field
  - Currently only allow editing message
- By branch name or by commit ID
- Also return list of edited items
- 3 tests: edit by commit ID, edit by branch name, fail commit ID not exist