### PR TITLE
Shorten automatically generated commit message after running a cell

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -455,8 +455,8 @@ class KishuForJupyter:
         """
         entry = CommitEntry(kind=CommitEntryKind.jupyter)
         entry.execution_count = result.execution_count
-        short_raw_cell = result.info.raw_cell if len(result.info.raw_cell) <= 20 else f"{result.info.raw_cell[:20]}..."
-        entry.message = f"Auto-commit after executing < {short_raw_cell} >"
+        short_raw_cell = result.info.raw_cell if len(result.info.raw_cell) <= 40 else f"{result.info.raw_cell[:40]}..."
+        entry.message = f"[run] {short_raw_cell}"
 
         # Jupyter-specific info for commit entry.
         entry.start_time = self._start_time


### PR DESCRIPTION
Based on discussion, new format:
```python
f"[run] {40_character_cell_code}"
```