### PR TITLE
Checkout IPython's execution count

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -414,6 +414,10 @@ class KishuForJupyter:
             if current_executed_cells is not None:
                 current_executed_cells[:] = commit_entry.executed_cells[:]
 
+        # Restore execution count.
+        if commit_entry.execution_count is not None:
+            self._ip.execution_count = commit_entry.execution_count + 1  # _ip.execution_count is the next count.
+
         # Restore user-namespace variables.
         commit_ns = commit_entry.restore_plan.run(database_path, commit_id)
         self._checkout_namespace(self._user_ns, commit_ns)
@@ -491,7 +495,7 @@ class KishuForJupyter:
         changed_vars = self._cr_planner.post_run_cell_update(entry.raw_cell, entry.end_time - entry.start_time)
 
         # Step forward internal data.
-        self._last_execution_count = result.execution_count
+        self._last_execution_count += 1
         self._start_time = None
 
         self._commit_entry(entry, changed_vars)
@@ -565,7 +569,7 @@ class KishuForJupyter:
 
     def commit(self, message: Optional[str] = None) -> BareReprStr:
         entry = CommitEntry(kind=CommitEntryKind.manual)
-        entry.execution_count = self._last_execution_count
+        entry.execution_count = self._ip.execution_count
         entry.message = message if message is not None else f"Manual commit after {entry.execution_count} executions."
         self.save_notebook()
         self._commit_entry(entry)

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -435,7 +435,7 @@ class TestKishuCommand:
 
             # Get the variable value before checkout.
             # The variable is printed so custom objects with no equality defined can be compared.
-            var_value_before, _ = notebook_session.run_code(f"print({var_to_compare})")
+            _, var_value_before = notebook_session.run_code(f"{var_to_compare}")
 
             # Run the rest of the notebook cells.
             for i in range(cell_num_to_restore, len(contents)):
@@ -457,7 +457,7 @@ class TestKishuCommand:
             KishuCommand.checkout(notebook_path, commit_id)
 
             # Get the variable value after checkout.
-            var_value_after, _ = notebook_session.run_code(f"print({var_to_compare})")
+            _, var_value_after = notebook_session.run_code(f"{var_to_compare}")
             assert var_value_before == var_value_after
 
     def test_track_executed_cells_with_checkout(
@@ -492,6 +492,7 @@ class TestKishuCommand:
                 "",  # PYTHONSTARTUP, https://ipython.readthedocs.io/en/stable/interactive/reference.html
                 *contents[:cell_num_to_restore+1],
             ]
+            assert status_result.commit_entry.execution_count == (cell_num_to_restore + 1)
 
             # Restore to that commit
             KishuCommand.checkout(notebook_path, commit_id)
@@ -510,6 +511,7 @@ class TestKishuCommand:
                 "x = 1",
                 "y = x + 10",
             ]
+            assert status_result_2.commit_entry.execution_count == (cell_num_to_restore + 1) + 2
 
     def test_checkout_reattach(
         self,


### PR DESCRIPTION
Previously we arguably didn't recover the execution count on checkout, and let the count continue from past executions. Some users want to keep the number consistent with "going back to the past".
- Restore the execution count on IPython's kernel
- Unit test checks for execution counts after checkout and after further execution