### PR TITLE
Copy namespace before cleanup and reset kernel at checkout

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -404,6 +404,9 @@ class KishuForJupyter:
         if commit_entry.restore_plan is None:
             raise ValueError("No restore plan found for commit_id = {}".format(commit_id))
 
+        # Reset ipython kernel.
+        self._ip.reset(new_session=True)
+
         # Restore notebook cells.
         if not skip_notebook and commit_entry.raw_nb is not None:
             self._checkout_notebook(commit_entry.raw_nb)

--- a/kishu/kishu/planning/plan.py
+++ b/kishu/kishu/planning/plan.py
@@ -262,7 +262,10 @@ class AtExitContext:
         while self._atexit_queue.qsize():
             func, args, kwargs = self._atexit_queue.get()
             atexit.unregister(func)
-            func(*args, **kwargs)
+            try:
+                func(*args, **kwargs)
+            except Exception:
+                pass
 
 
 @dataclass
@@ -327,4 +330,4 @@ class RestorePlan:
                             self.actions[rerun_cell_action.step_order] = rerun_cell_action
                         break
                 else:
-                    return Namespace(ctx.shell.user_ns)
+                    return Namespace(ctx.shell.user_ns.copy())


### PR DESCRIPTION
Turns out one of atexit functions clears the namespace. Checkout wouldn't work work in this case.

This PR copies the namespace dictionary (not deep copy) before running atexit functions.

<img width="750" alt="Screenshot 2024-02-27 at 21 03 38" src="https://github.com/illinoisdata/kishu/assets/21223634/d0a0b6da-d878-4e4f-9f0c-b0b870c1ca1f">
