### PR TITLE
Reset only history manager

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -409,7 +409,9 @@ class KishuForJupyter:
             raise ValueError("No restore plan found for commit_id = {}".format(commit_id))
 
         # Reset ipython kernel.
-        self._ip.reset(new_session=True)
+        assert self._ip is not None
+        if self._ip.history_manager is not None:
+            self._ip.history_manager.reset(new_session=True)
 
         # Restore notebook cells.
         if not skip_notebook and commit_entry.raw_nb is not None:


### PR DESCRIPTION
When we reset the entire ip shell, `post_run_cell` is re-registered and executed twice later. We wanted to reset it to indirectly reset the history manager.

Now we should only reset the history manager explicitly