### PR TITLE
Fix bug: Update commit detail when auto refresh

### DIFF
--- a/kishuboard/src/App.tsx
+++ b/kishuboard/src/App.tsx
@@ -376,12 +376,13 @@ function App() {
         if(!selectedCommitID || newGraph.commits.length > commits.length) {
             setSelectedCommitID(newGraph.currentHead);
             setSelectedBranchID(newGraph.currentHeadBranch);
+            await refreshSelectedCommit(newGraph.currentHead);
         }
-        await refreshSelectedCommit();}
+        }
     }
 
-    async function refreshSelectedCommit(){
-        await loadCommitDetail(selectedCommitID!, setSelectedCommit, setError);
+    async function refreshSelectedCommit(commitID: string){
+        await loadCommitDetail(commitID, setSelectedCommit, setError);
     }
 
 


### PR DESCRIPTION
Because the async nature of react state update, previously selectedCommitID may not be updated when we refresh commit detail.

Fix the issue by passing the new commitID directly to the function to refresh selected commit detail.