### PR TITLE
Disable 3.9 and 3.10 tests

### DIFF
--- a/.github/workflows/kishu.yml
+++ b/.github/workflows/kishu.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        # python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
So far the workflow uses ~700/3000 minutes. Without disabling them, we are on course to spend all the action minutes before next month.