### PR TITLE
Release post_run_cell and wait to commit notebook auto-saved by Jupyter

### DIFF
--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -284,6 +284,7 @@ def basic_execution_ids(kishu_jupyter) -> Generator[List[str], None, None]:
     kishu_jupyter.pre_run_cell(info)
     kishu_jupyter.post_run_cell(JupyterResultMock(
         info=info, execution_count=execution_count))
+    kishu_jupyter.wait_until_commit_finishes()
 
     yield ["0:0:1", "0:0:2", "0:0:3"]  # List of commit IDs
 


### PR DESCRIPTION
Saving notebook has been inaccurately saved the notebook state before cell update, leading to 1) latest execution number not recorded in Kishu commit, 2) lost cell output when many executions are queued.

The main problem is that saving notebook during `pre_run_cell` or `post_run_cell` is premature. In fact, committing during `post_run_cell` is also premature. At that point of time, the notebook does not contain the recently executed cell output and so the notebook does not represent "after-execution" state.

This change postpones the commit later and release `post_run_cell` so that
1. IPython returns cell output to Jupyter Frontend.
2. Jupyter Frontend updates cell output in its notebook buffer.
3. Jupyter Frontend auto-save notebook buffer to notebook file.

Then, after waiting, Kishu can read the latest notebook file and commit as usual. This fixes both problem: 1) latest execution number is now recorded in Kishu commit, 2) Kishu works with many queued executions (and "Run All").

Since this change relies on Jupyter Frontend, it needs to enable auto-saving (every 1 second if dirty) on attachment.

TODO (later, after this change):
1. Synchronize with the auto-saving instead of sleeping.
2. Or, figure out how to save from within IPython. Current `ipylab.JupyterFrontEnd` approach is still unreliable as it can drop cell output update in Jupyter Frontend.