### PR TITLE
Capture and restore executed cell outputs

### DIFF
--- a/kishu/kishu/commands.py
+++ b/kishu/kishu/commands.py
@@ -279,6 +279,7 @@ class FESelectedCommitVariable:
 class FESelectedCommit:
     commit: FECommit
     executed_cells: List[str]
+    executed_outputs: Dict[int, str]
     cells: List[FESelectedCommitCell]
     variables: List[FESelectedCommitVariable]
 
@@ -802,8 +803,9 @@ class KishuCommand:
             for key, value in commit_ns.to_dict().items()
         ]
 
-        # Compile list of executed cells.
+        # Compile list of executed cells and outputs.
         executed_cells = [] if commit_entry.executed_cells is None else commit_entry.executed_cells
+        executed_outputs = {} if commit_entry.executed_outputs is None else commit_entry.executed_outputs
 
         # Compile list of cells.
         cells: List[FESelectedCommitCell] = []
@@ -835,6 +837,7 @@ class KishuCommand:
         return FESelectedCommit(
             commit=commit_summary,
             executed_cells=executed_cells,
+            executed_outputs=executed_outputs,
             variables=variables,
             cells=cells,
         )

--- a/kishu/kishu/jupyter/namespace.py
+++ b/kishu/kishu/jupyter/namespace.py
@@ -78,6 +78,9 @@ class Namespace:
     def ipython_in(self) -> Optional[List[str]]:
         return self._tracked_namespace["In"] if "In" in self._tracked_namespace else None
 
+    def ipython_out(self) -> Optional[Dict[int, Any]]:
+        return self._tracked_namespace["Out"] if "Out" in self._tracked_namespace else None
+
     def subset(self, varnames: Set[str]) -> Namespace:
         return Namespace({k: self._tracked_namespace[k] for k in varnames if k in self})
 

--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -444,6 +444,17 @@ class KishuForJupyter:
             if current_executed_cells is not None:
                 current_executed_cells[:] = commit_entry.executed_cells[:]
 
+        # Restore IPython output maps.
+        # Currently, this restores string representation of the outputs.
+        # TODO: Restore the original object.
+        if commit_entry.executed_outputs is not None:
+            current_executed_outputs = self._user_ns.ipython_out()
+            if current_executed_outputs is not None:
+                current_executed_outputs.update(commit_entry.executed_outputs)
+                for key in current_executed_outputs.keys():
+                    if key not in commit_entry.executed_outputs:
+                        del current_executed_outputs[key]
+
         # Restore execution count.
         if commit_entry.execution_count is not None:
             self._ip.execution_count = commit_entry.execution_count + 1  # _ip.execution_count is the next count.
@@ -632,6 +643,8 @@ class KishuForJupyter:
 
         # Observe all cells and extract notebook informations.
         entry.executed_cells = self._user_ns.ipython_in()
+        executed_outputs = self._user_ns.ipython_out()
+        entry.executed_outputs = {k: str(v) for k, v in executed_outputs.items()} if executed_outputs is not None else None
         entry.raw_nb, entry.formatted_cells = self._all_notebook_cells()
         if entry.formatted_cells is not None:
             code_cells = []

--- a/kishu/kishu/storage/commit.py
+++ b/kishu/kishu/storage/commit.py
@@ -61,6 +61,7 @@ class CommitEntry:
 
     checkpoint_runtime_s: Optional[float] = None
     executed_cells: Optional[List[str]] = None
+    executed_outputs: Optional[Dict[int, str]] = None
     raw_nb: Optional[str] = None
     formatted_cells: Optional[List[FormattedCell]] = None
     restore_plan: Optional[kishu.planning.plan.RestorePlan] = None

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -139,6 +139,7 @@ class TestKishuCommand:
                 # "y = 2",
                 # "y = x + 1",
             ],
+            executed_outputs={},
             message=status_result.commit_entry.message,  # Not tested,
             timestamp=status_result.commit_entry.timestamp,  # Not tested
             ahg_string=status_result.commit_entry.ahg_string,  # Not tested
@@ -364,6 +365,7 @@ class TestKishuCommand:
                 # "y = 2",
                 # "y = x + 1",
             ],
+            executed_outputs={},
             cells=fe_commit_result.cells,  # Not tested
             variables=[],
         )
@@ -561,6 +563,7 @@ class TestKishuCommand:
                     "# Record imported libraries\nimport numpy as np\nfrom numpy import random",
                     "b = 1",
                 ],
+                executed_outputs={},
                 cells=fe_commit_result.cells,  # Not tested
                 variables=fe_commit_result.variables,  # Not tested
             )
@@ -596,6 +599,7 @@ class TestKishuCommand:
                     "b = 1",
                     "x = 1",
                 ],
+                executed_outputs={},
                 cells=fe_commit_result_2.cells,  # Not tested
                 variables=fe_commit_result_2.variables,  # Not tested
             )


### PR DESCRIPTION
- Get cell outputs from `Out`. Currently capture string representation of those output objects
- Restore cell outputs to make capturing consistent
- Attach outputs to FECommit endpoint