### PR TITLE
Change VariableSnapshots to use sets of (linked) variable names instead of singular variable names

### DIFF
--- a/kishu/kishu/diff.py
+++ b/kishu/kishu/diff.py
@@ -259,7 +259,7 @@ class KishuDiff:
                     # get the corresponding matched hunks from edr_diff of the add_remove groups
                     refined_hunks = DiffAlgorithms.edr_diff(origin=remove_hunks, destination=add_hunks).diff_hunks
                     # replace the add_remove groups with edr_diff result
-                    diff_hunks[_get_new_index(from_idx): _get_new_index(to_idx) + 1] = refined_hunks
+                    diff_hunks[_get_new_index(from_idx) : _get_new_index(to_idx) + 1] = refined_hunks
                     offset_diff += len(refined_hunks) - (to_idx - from_idx + 1)
 
                 # try to find the next group of add-remove
@@ -277,7 +277,7 @@ class KishuDiff:
             # get the corresponding matched hunks from edr_diff of the add_remove groups
             refined_hunks = DiffAlgorithms.edr_diff(origin=remove_hunks, destination=add_hunks).diff_hunks
             # replace the add_remove groups with edr_diff result
-            diff_hunks[_get_new_index(from_idx): _get_new_index(to_idx) + 1] = refined_hunks
+            diff_hunks[_get_new_index(from_idx) : _get_new_index(to_idx) + 1] = refined_hunks
             offset_diff += len(refined_hunks) - (to_idx - from_idx + 1)
 
         return diff_hunks

--- a/kishu/kishu/planning/optimizer.py
+++ b/kishu/kishu/planning/optimizer.py
@@ -29,10 +29,7 @@ class Optimizer:
     """
 
     def __init__(
-        self,
-        ahg: AHG,
-        active_vss: List[VariableSnapshot],
-        already_stored_vss: Optional[Set[VersionedName]] = None
+        self, ahg: AHG, active_vss: List[VariableSnapshot], already_stored_vss: Optional[Set[VersionedName]] = None
     ) -> None:
         """
         Creates an optimizer with a migration speed estimate. The AHG and active VS fields
@@ -79,9 +76,11 @@ class Optimizer:
                 # Else, recurse into input variables of the CE.
                 prerequisite_ces.add(current.cell_num)
                 for vs in current.src_vss:
-                    if VersionedName(vs.name, vs.version) not in self.active_versioned_names \
-                            and VersionedName(vs.name, vs.version) not in self.already_stored_vss \
-                            and VersionedName(vs.name, vs.version) not in visited:
+                    if (
+                        VersionedName(vs.name, vs.version) not in self.active_versioned_names
+                        and VersionedName(vs.name, vs.version) not in self.already_stored_vss
+                        and VersionedName(vs.name, vs.version) not in visited
+                    ):
                         self.dfs_helper(vs, visited, prerequisite_ces)
 
         elif isinstance(current, VariableSnapshot):
@@ -130,9 +129,7 @@ class Optimizer:
             active_versioned_name = VersionedName(active_vs.name, active_vs.version)
             flow_graph.add_node(active_versioned_name)
             flow_graph.add_edge(
-                "source",
-                active_versioned_name,
-                capacity=active_vs.size / self._optimizer_context.network_bandwidth
+                "source", active_versioned_name, capacity=active_vs.size / self._optimizer_context.network_bandwidth
             )
 
         # Add all CEs as nodes, connect them with the sink with edge capacity equal to recomputation cost.

--- a/kishu/kishu/planning/plan.py
+++ b/kishu/kishu/planning/plan.py
@@ -103,6 +103,7 @@ class IncrementalWriteCheckpointAction(CheckpointAction):
     """
     Stores VarNamesToObjects into database incrementally.
     """
+
     def __init__(self, vses_to_store: List[VariableSnapshot], filename: str, exec_id: str) -> None:
         self.vses_to_store = vses_to_store
         self.filename = filename
@@ -184,12 +185,7 @@ class IncrementalCheckpointPlan:
         self.actions = actions
 
     @staticmethod
-    def create(
-        user_ns: Namespace,
-        checkpoint_file: str,
-        exec_id: str,
-        vses_to_store: List[VariableSnapshot]
-    ):
+    def create(user_ns: Namespace, checkpoint_file: str, exec_id: str, vses_to_store: List[VariableSnapshot]):
         """
         @param user_ns  A dictionary representing a target variable namespace. In Jupyter, this
                 can be optained by `get_ipython().user_ns`.
@@ -200,11 +196,7 @@ class IncrementalCheckpointPlan:
 
     @classmethod
     def set_up_actions(
-        cls,
-        user_ns: Namespace,
-        checkpoint_file: str,
-        exec_id: str,
-        vses_to_store: List[VariableSnapshot]
+        cls, user_ns: Namespace, checkpoint_file: str, exec_id: str, vses_to_store: List[VariableSnapshot]
     ) -> List[CheckpointAction]:
         if user_ns is None or checkpoint_file is None:
             raise ValueError("Fields are not properly initialized.")

--- a/kishu/kishu/planning/planner.py
+++ b/kishu/kishu/planning/planner.py
@@ -141,17 +141,14 @@ class CheckpointRestorePlanner:
                 self._user_ns.keyset(),
                 linked_var_pairs,
                 modified_vars_structure,
-                deleted_vars
+                deleted_vars,
             )
         )
 
         return ChangedVariables(created_vars, modified_vars_value, modified_vars_structure, deleted_vars)
 
     def generate_checkpoint_restore_plans(
-        self,
-        database_path: str,
-        commit_id: str,
-        parent_commit_ids: Optional[List[str]] = None
+        self, database_path: str, commit_id: str, parent_commit_ids: Optional[List[str]] = None
     ) -> Tuple[CheckpointPlan, RestorePlan]:
         # Retrieve active VSs from the graph. Active VSs are correspond to the latest instances/versions of each variable.
         active_vss = self._ahg.get_active_variable_snapshots()
@@ -172,16 +169,13 @@ class CheckpointRestorePlanner:
             if parent_commit_ids is None:
                 parent_commit_ids = []
             stored_versioned_names = KishuCheckpoint(database_path).get_stored_versioned_names(parent_commit_ids)
-            active_vss = [vs for vs in active_vss if
-                          VersionedName(vs.name, vs.version) not in stored_versioned_names]
+            active_vss = [vs for vs in active_vss if VersionedName(vs.name, vs.version) not in stored_versioned_names]
 
         # Initialize optimizer.
         # Migration speed is set to (finite) large value to prompt optimizer to store all serializable variables.
         # Currently, a variable is recomputed only if it is unserialzable.
         optimizer = Optimizer(
-            self._ahg,
-            active_vss,
-            stored_versioned_names if self._planner_context.incremental_store else None
+            self._ahg, active_vss, stored_versioned_names if self._planner_context.incremental_store else None
         )
 
         # Use the optimizer to compute the checkpointing configuration.
@@ -198,16 +192,13 @@ class CheckpointRestorePlanner:
                 self._user_ns,
                 database_path,
                 commit_id,
-                list(self._ahg.get_active_variable_snapshots_dict()[vn.name] for vn in vss_to_migrate)
+                list(self._ahg.get_active_variable_snapshots_dict()[vn.name] for vn in vss_to_migrate),
             )
 
         else:
             # Create checkpoint plan using optimization results.
             checkpoint_plan = CheckpointPlan.create(
-                self._user_ns,
-                database_path,
-                commit_id,
-                list(chain.from_iterable([vs.name for vs in vss_to_migrate]))
+                self._user_ns, database_path, commit_id, list(chain.from_iterable([vs.name for vs in vss_to_migrate]))
             )
 
         # Create restore plan using optimization results.
@@ -216,10 +207,7 @@ class CheckpointRestorePlanner:
         return checkpoint_plan, restore_plan
 
     def _generate_restore_plan(
-        self,
-        ces_to_recompute: Set[int],
-        ce_to_vs_map: Dict[int, List[VariableName]],
-        req_func_mapping: Dict[int, Set[int]]
+        self, ces_to_recompute: Set[int], ce_to_vs_map: Dict[int, List[VariableName]], req_func_mapping: Dict[int, Set[int]]
     ) -> RestorePlan:
         """
         Generates a restore plan based on results from the optimizer.
@@ -242,7 +230,7 @@ class CheckpointRestorePlanner:
                 restore_plan.add_load_variable_restore_action(
                     ce.cell_num,
                     list(chain.from_iterable(ce_to_vs_map[ce.cell_num])),
-                    [(cell_num, ce_dict[cell_num].cell) for cell_num in req_func_mapping[ce.cell_num]]
+                    [(cell_num, ce_dict[cell_num].cell) for cell_num in req_func_mapping[ce.cell_num]],
                 )
         return restore_plan
 

--- a/kishu/tests/planning/test_ahg.py
+++ b/kishu/tests/planning/test_ahg.py
@@ -22,13 +22,7 @@ def test_update_graph():
     ahg = AHG()
 
     # x and y are created
-    ahg.update_graph(
-        AHGUpdateInfo(
-            version=1,
-            cell_runtime_s=1.0,
-            current_variables={"x", "y"}
-        )
-    )
+    ahg.update_graph(AHGUpdateInfo(version=1, cell_runtime_s=1.0, current_variables={"x", "y"}))
 
     # x is read and modified, z is created, y is deleted
     ahg.update_graph(
@@ -38,7 +32,7 @@ def test_update_graph():
             accessed_variables={"x"},
             current_variables={"x", "z"},
             modified_variables={"x"},
-            deleted_variables={"y"}
+            deleted_variables={"y"},
         )
     )
 
@@ -70,10 +64,7 @@ def test_update_graph_with_connected_components():
     linked_variable_pairs = [("a", "b"), ("b", "c"), ("d", "e")]
     ahg.update_graph(
         AHGUpdateInfo(
-            version=1,
-            cell_runtime_s=1.0,
-            current_variables=current_variables,
-            linked_variable_pairs=linked_variable_pairs
+            version=1, cell_runtime_s=1.0, current_variables=current_variables, linked_variable_pairs=linked_variable_pairs
         )
     )
 
@@ -81,8 +72,11 @@ def test_update_graph_with_connected_components():
 
     # 3 variable snapshots
     assert len(active_variable_snapshots) == 3
-    assert set(vs.name for vs in active_variable_snapshots) == \
-        {frozenset({"a", "b", "c"}), frozenset({"d", "e"}), frozenset("f")}
+    assert set(vs.name for vs in active_variable_snapshots) == {
+        frozenset({"a", "b", "c"}),
+        frozenset({"d", "e"}),
+        frozenset("f"),
+    }
 
     # 6 variables in total
     assert ahg.get_variable_names() == {"a", "b", "c", "d", "e", "f"}
@@ -104,10 +98,7 @@ def test_create_vs_merge_connected_components():
     # components 'abc' and 'def' are merged.
     ahg.update_graph(
         AHGUpdateInfo(
-            version=1,
-            cell_runtime_s=1.0,
-            current_variables=current_variables,
-            linked_variable_pairs=linked_variable_pairs
+            version=1, cell_runtime_s=1.0, current_variables=current_variables, linked_variable_pairs=linked_variable_pairs
         )
     )
 
@@ -125,13 +116,13 @@ def test_create_vs_merge_connected_components():
 
 def test_create_vs_split_connected_component():
     """
-        Test modification detection for splitting comoponents:
+    Test modification detection for splitting comoponents:
 
-        a---b
+    a---b
 
-        split
+    split
 
-        a   b
+    a   b
     """
     ahg = AHG()
 
@@ -141,10 +132,7 @@ def test_create_vs_split_connected_component():
     # 'ab' is in 1 component.
     ahg.update_graph(
         AHGUpdateInfo(
-            version=1,
-            cell_runtime_s=1.0,
-            current_variables=current_variables,
-            linked_variable_pairs=linked_variable_pairs
+            version=1, cell_runtime_s=1.0, current_variables=current_variables, linked_variable_pairs=linked_variable_pairs
         )
     )
 
@@ -158,12 +146,7 @@ def test_create_vs_split_connected_component():
 
     # 'ab' is split into 2 components.
     ahg.update_graph(
-        AHGUpdateInfo(
-            version=2,
-            cell_runtime_s=1.0,
-            current_variables=current_variables,
-            modified_variables={"b"}
-        )
+        AHGUpdateInfo(version=2, cell_runtime_s=1.0, current_variables=current_variables, modified_variables={"b"})
     )
 
     active_variable_snapshots = ahg.get_active_variable_snapshots()
@@ -178,13 +161,13 @@ def test_create_vs_split_connected_component():
 
 def test_create_vs_modify_connected_component():
     """
-        Test modification detection for splitting comoponents:
+    Test modification detection for splitting comoponents:
 
-        a---b   c
+    a---b   c
 
-        split
+    split
 
-        a   b---c
+    a   b---c
     """
     ahg = AHG()
 
@@ -194,10 +177,7 @@ def test_create_vs_modify_connected_component():
     # 2 components: 'ab' and 'c'.
     ahg.update_graph(
         AHGUpdateInfo(
-            version=1,
-            cell_runtime_s=1.0,
-            current_variables=current_variables,
-            linked_variable_pairs=linked_variable_pairs
+            version=1, cell_runtime_s=1.0, current_variables=current_variables, linked_variable_pairs=linked_variable_pairs
         )
     )
 
@@ -216,7 +196,7 @@ def test_create_vs_modify_connected_component():
             cell_runtime_s=1.0,
             current_variables=current_variables,
             linked_variable_pairs=[("c", "b")],
-            modified_variables={"b"}
+            modified_variables={"b"},
         )
     )
 

--- a/kishu/tests/planning/test_plan.py
+++ b/kishu/tests/planning/test_plan.py
@@ -129,8 +129,8 @@ def test_fallback_recomputation():
 
 def test_store_versioned_names(enable_incremental_store):
     """
-        Tests that the VARIABLE_SNAPSHOT table are populated correctly for incremental storage.
-        TODO: add test for loading incrementally once that is implemented.
+    Tests that the VARIABLE_SNAPSHOT table are populated correctly for incremental storage.
+    TODO: add test for loading incrementally once that is implemented.
     """
     shell = InteractiveShell()
     shell.run_cell("a = 1")
@@ -143,7 +143,7 @@ def test_store_versioned_names(enable_incremental_store):
 
     # save
     exec_id = 1
-    vses_to_store = [VariableSnapshot(frozenset({'a', 'b'}), 1), VariableSnapshot(frozenset('c'), 1)]
+    vses_to_store = [VariableSnapshot(frozenset({"a", "b"}), 1), VariableSnapshot(frozenset("c"), 1)]
     checkpoint = IncrementalCheckpointPlan.create(user_ns, filename, exec_id, vses_to_store)
     checkpoint.run(user_ns)
 

--- a/kishu/tests/planning/test_planner.py
+++ b/kishu/tests/planning/test_planner.py
@@ -41,10 +41,7 @@ class PlannerManager:
         return self.planner.post_run_cell_update(cell_code, cell_runtime)
 
     def checkpoint_session(
-        self,
-        filename: str,
-        commit_id: str,
-        parent_commit_ids: Optional[List[str]] = None
+        self, filename: str, commit_id: str, parent_commit_ids: Optional[List[str]] = None
     ) -> Tuple[CheckpointPlan, RestorePlan]:
         checkpoint_plan, restore_plan = self.planner.generate_checkpoint_restore_plans(filename, commit_id, parent_commit_ids)
         checkpoint_plan.run(self.planner._user_ns)

--- a/kishu/tests/storage/test_checkpoint.py
+++ b/kishu/tests/storage/test_checkpoint.py
@@ -1,86 +1,68 @@
+import pytest
 import sqlite3
 
 from kishu.jupyter.namespace import Namespace
 from kishu.planning.ahg import VariableSnapshot, VersionedName
 from kishu.storage.checkpoint import CHECKPOINT_TABLE, KishuCheckpoint, VARIABLE_SNAPSHOT_TABLE
-from kishu.storage.config import Config
 from kishu.storage.path import KishuPath
 
 
-def test_create_table_no_incremental_checkpointing():
-    filename = KishuPath.database_path("test")
-    KishuCheckpoint(filename).init_database()
+class TestKishuCheckpoint:
+    @pytest.fixture
+    def db_path_name(self):
+        return KishuPath.database_path("test")
 
-    con = sqlite3.connect(filename)
-    cur = con.cursor()
+    @pytest.fixture
+    def kishu_checkpoint(self, db_path_name):
+        """Fixture for initializing a KishuBranch instance."""
+        kishu_checkpoint = KishuCheckpoint(db_path_name)
+        kishu_checkpoint.init_database()
+        yield kishu_checkpoint
+        kishu_checkpoint.drop_database()
 
-    # The checkpoint table should exist.
-    cur.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{CHECKPOINT_TABLE}';")
-    assert cur.fetchone()[0] == 1
+    def test_create_table_no_incremental_checkpointing(self, kishu_checkpoint):
+        con = sqlite3.connect(kishu_checkpoint.database_path)
+        cur = con.cursor()
 
-    # The variable snapshot table should not exist.
-    cur.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{VARIABLE_SNAPSHOT_TABLE}';")
-    assert cur.fetchone()[0] == 0
+        # The checkpoint table should exist.
+        cur.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{CHECKPOINT_TABLE}';")
+        assert cur.fetchone()[0] == 1
 
+        # The variable snapshot table should not exist.
+        cur.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{VARIABLE_SNAPSHOT_TABLE}';")
+        assert cur.fetchone()[0] == 0
 
-def test_create_table_with_incremental_checkpointing():
-    Config.set("PLANNER", "incremental_store", True)
+    def test_create_table_with_incremental_checkpointing(self, enable_incremental_store, kishu_checkpoint):
+        con = sqlite3.connect(kishu_checkpoint.database_path)
+        cur = con.cursor()
 
-    filename = KishuPath.database_path("test")
-    KishuCheckpoint(filename).init_database()
+        # The checkpoint table should exist.
+        cur.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{CHECKPOINT_TABLE}';")
+        assert cur.fetchone()[0] == 1
 
-    con = sqlite3.connect(filename)
-    cur = con.cursor()
+        # The variable snapshot table should exist.
+        cur.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{VARIABLE_SNAPSHOT_TABLE}';")
+        assert cur.fetchone()[0] == 1
 
-    # The checkpoint table should exist.
-    cur.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{CHECKPOINT_TABLE}';")
-    assert cur.fetchone()[0] == 1
+    def test_store_variable_snapshots(self, enable_incremental_store, kishu_checkpoint):
+        # Insert 2 variable snapshots
+        empty_list = []
+        empty_nested_list = [empty_list]
+        kishu_checkpoint.store_variable_snapshots(
+            "1",
+            [VariableSnapshot(frozenset({"b", "a"}), 1), VariableSnapshot(frozenset("c"), 1)],
+            Namespace({"a": empty_list, "b": empty_nested_list, "c": 1}),
+        )
 
-    # The variable snapshot table should exist.
-    cur.execute(f"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='{VARIABLE_SNAPSHOT_TABLE}';")
-    assert cur.fetchone()[0] == 1
+        # Both variable snapshots should be found.
+        nameset = kishu_checkpoint.get_stored_versioned_names(["1"])
+        assert nameset == {VersionedName(frozenset({"a", "b"}), 1), VersionedName(frozenset("c"), 1)}
 
+    def test_select_variable_snapshots(self, enable_incremental_store, kishu_checkpoint):
+        # Create 2 commits
+        kishu_checkpoint.store_variable_snapshots("1", [VariableSnapshot(frozenset("a"), 1)], Namespace({"a": 1}))
+        kishu_checkpoint.store_variable_snapshots("2", [VariableSnapshot(frozenset("b"), 1)], Namespace({"b": 2}))
 
-def test_store_variable_snapshots():
-    Config.set('PLANNER', 'incremental_store', True)
-
-    filename = KishuPath.database_path("test")
-    kishu_checkpoint = KishuCheckpoint(filename)
-    kishu_checkpoint.init_database()
-
-    # Insert 2 variable snapshots
-    empty_list = []
-    empty_nested_list = [empty_list]
-    kishu_checkpoint.store_variable_snapshots(
-        "1",
-        [VariableSnapshot(frozenset({"b", "a"}), 1), VariableSnapshot(frozenset("c"), 1)],
-        Namespace({"a": empty_list, "b": empty_nested_list, "c": 1})
-    )
-
-    # Both variable snapshots should be found.
-    nameset = kishu_checkpoint.get_stored_versioned_names(["1"])
-    assert nameset == {VersionedName(frozenset({"a", "b"}), 1), VersionedName(frozenset("c"), 1)}
-
-
-def test_select_variable_snapshots():
-    Config.set('PLANNER', 'incremental_store', True)
-
-    filename = KishuPath.database_path("test")
-    kishu_checkpoint = KishuCheckpoint(filename)
-    kishu_checkpoint.init_database()
-
-    # Create 2 commits
-    kishu_checkpoint.store_variable_snapshots(
-        "1",
-        [VariableSnapshot(frozenset("a"), 1)],
-        Namespace({"a": 1})
-    )
-    kishu_checkpoint.store_variable_snapshots(
-        "2",
-        [VariableSnapshot(frozenset("b"), 1)],
-        Namespace({"b": 2})
-    )
-
-    # Only the VS stored in commit 1 ("a") should be returned.
-    nameset = kishu_checkpoint.get_stored_versioned_names(["1"])
-    assert nameset == {VersionedName(frozenset("a"), 1)}
+        # Only the VS stored in commit 1 ("a") should be returned.
+        nameset = kishu_checkpoint.get_stored_versioned_names(["1"])
+        assert nameset == {VersionedName(frozenset("a"), 1)}


### PR DESCRIPTION
Change VariableSnapshots to use sets of (linked) variable names instead of singular variable names. This cuts down on redundancy caused by having to infer linked variable pairs everywhere in the codebase.