### PR TITLE
Erase lower execution counts and outputs when rollback execution

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -730,7 +730,8 @@ class KishuForJupyter:
                     execution_count=None,
                 ))
             # else:
-            #     raise ValueError(f"Unknown cell type: {cell.cell_type}")
+            #     # TODO: Logs this as a warning.
+            #     print(f"Unknown cell type: {cell.cell_type}")
         return nbformat.writes(nb), nb_cells
 
     def _parse_cell_output(self, cell_outputs: List[Dict[Any, Any]]) -> Optional[str]:


### PR DESCRIPTION
End-to-end test has passed. 

Unit test: IDK how to write a unit test for this. bc when running a notebook with "nbconvert" package (with which we do unit test), it won't update the exec count in the real notebook file. So the exec count for all the cells are always "null" all the time in the ipynb file.