### PR TITLE
Move connection files into SQLite

### DIFF
--- a/kishu/kishu/storage/connection.py
+++ b/kishu/kishu/storage/connection.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from kishu.storage.path import KishuPath
+
+CONNECTION_TABLE = "connection"
+CONNECTION_KEY = "CONN"
+
+
+@dataclass
+class JupyterConnectionInfo:
+    kernel_id: str
+    notebook_path: str
+
+
+"""
+Kishu Jupyter connection information.
+"""
+
+
+class KishuConnection:
+
+    def __init__(self, key: str, path: Path, kernel_id: str):
+        self._key = key
+        self._path = path
+        self._kernel_id = kernel_id
+        self.database_path = KishuPath.database_path(self._key)
+
+    def init_database(self) -> None:
+        con = sqlite3.connect(self.database_path)
+        cur = con.cursor()
+        cur.execute(f"create table if not exists {CONNECTION_TABLE} (conn primary key, kernel_id text, notebook_path text)")
+        con.commit()
+
+    def drop_database(self):
+        con = sqlite3.connect(self.database_path)
+        cur = con.cursor()
+        cur.execute(f"drop table if exists {CONNECTION_TABLE}")
+        con.commit()
+
+    def record_connection(self) -> None:
+        con = sqlite3.connect(self.database_path)
+        cur = con.cursor()
+        query = f"insert or replace into {CONNECTION_TABLE} values ('{CONNECTION_KEY}', ?, ?)"
+        cur.execute(query, (self._kernel_id, str(self._path)))
+        con.commit()
+
+    @staticmethod
+    def try_retrieve_connection(key: str) -> Optional[JupyterConnectionInfo]:
+        con = sqlite3.connect(KishuPath.database_path(key))
+        cur = con.cursor()
+        try:
+            cur.execute(f"select kernel_id, notebook_path from {CONNECTION_TABLE} where conn = '{CONNECTION_KEY}'")
+            res: Optional[tuple] = cur.fetchone()
+            if not res:
+                return None
+            kernel_id, notebook_path = res
+            return JupyterConnectionInfo(kernel_id=kernel_id, notebook_path=notebook_path)
+        except sqlite3.OperationalError:
+            return None
+        finally:
+            con.close()

--- a/kishu/kishu/storage/path.py
+++ b/kishu/kishu/storage/path.py
@@ -27,10 +27,6 @@ class KishuPath:
         return os.path.join(KishuPath.notebook_directory(notebook_key), "ckpt.sqlite")
 
     @staticmethod
-    def connection_path(notebook_key: str) -> str:
-        return os.path.join(KishuPath.notebook_directory(notebook_key), "connection.json")
-
-    @staticmethod
     def exists(notebook_key: str) -> bool:
         return os.path.exists(os.path.join(KishuPath.kishu_directory(), notebook_key))
 

--- a/kishu/tests/storage/test_connection.py
+++ b/kishu/tests/storage/test_connection.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import patch
+
+import sqlite3
+
+from kishu.notebook_id import NotebookId
+from kishu.storage.connection import KishuConnection, CONNECTION_TABLE
+from kishu.storage.path import KishuPath
+
+
+class TestKishuConnection:
+
+    @pytest.fixture
+    def notebook_id(self):
+        """Fixture for a mock notebook_id object."""
+        return NotebookId("test_key", "test_kernel_1", "/path/to/test_notebook")
+
+    @pytest.fixture
+    def connection(self, notebook_id):
+        """Fixture for initializing a KishuConnection instance."""
+        connection = KishuConnection(
+            key=notebook_id.key(),
+            path=notebook_id.path(),
+            kernel_id=notebook_id.kernel_id(),
+        )
+        connection.init_database()
+        yield connection
+        connection.drop_database()
+
+    def test_init_database(self, connection, notebook_id):
+        """Test initializing the database."""
+        # Check if the table is correctly created
+        con = sqlite3.connect(KishuPath.database_path(notebook_id.key()))
+        cur = con.cursor()
+        cur.execute(f"SELECT name FROM sqlite_master WHERE type='table' AND name='{CONNECTION_TABLE}'")
+        table_exists = cur.fetchone()
+        con.close()
+
+        assert table_exists is not None
+
+    def test_drop_database(self, connection, notebook_id):
+        """Test dropping the database."""
+        connection.drop_database()
+
+        # Verify that the table no longer exists
+        con = sqlite3.connect(KishuPath.database_path(notebook_id.key()))
+        cur = con.cursor()
+        cur.execute(f"SELECT name FROM sqlite_master WHERE type='table' AND name='{CONNECTION_TABLE}'")
+        table_exists = cur.fetchone()
+        con.close()
+
+        assert table_exists is None
+
+    def test_record_connection(self, connection, notebook_id):
+        """Test recording a connection and verifying it in the database."""
+        connection.record_connection()
+
+        # Verify the connection record
+        conn_info = KishuConnection.try_retrieve_connection(notebook_id.key())
+
+        assert conn_info is not None
+        assert conn_info.kernel_id == notebook_id.kernel_id()
+        assert conn_info.notebook_path == str(notebook_id.path())
+
+    def test_try_retrieve_connection_none(self, notebook_id):
+        """Test retrieving a connection when none exists in the database."""
+        conn_info = KishuConnection.try_retrieve_connection(notebook_id.key())
+        assert conn_info is None
+
+    def test_try_retrieve_connection_no_record(self, connection, notebook_id):
+        """Test retrieving a connection when none exists in the database."""
+        conn_info = KishuConnection.try_retrieve_connection(notebook_id.key())
+        assert conn_info is None
+
+    def test_sqlite3_operational_error_init_database(self, connection, notebook_id):
+        """Test sqlite3.OperationalError during init_database."""
+        with patch("sqlite3.connect", side_effect=sqlite3.OperationalError):
+            with pytest.raises(sqlite3.OperationalError):
+                connection.init_database()
+
+    def test_sqlite3_operational_error_drop_database(self, connection, notebook_id):
+        """Test sqlite3.OperationalError during drop_database."""
+        with patch("sqlite3.connect", side_effect=sqlite3.OperationalError):
+            with pytest.raises(sqlite3.OperationalError):
+                connection.drop_database()
+
+    def test_sqlite3_operational_error_record_connection(self, connection, notebook_id):
+        """Test sqlite3.OperationalError during record_connection."""
+        with patch("sqlite3.connect", side_effect=sqlite3.OperationalError):
+            with pytest.raises(sqlite3.OperationalError):
+                connection.record_connection()
+
+    def test_sqlite3_operational_error_try_retrieve_connection(self, notebook_id):
+        """Test sqlite3.OperationalError during try_retrieve_connection."""
+        with patch("sqlite3.connect", side_effect=sqlite3.OperationalError):
+            with pytest.raises(sqlite3.OperationalError):
+                KishuConnection.try_retrieve_connection(notebook_id.key())


### PR DESCRIPTION
As a part of moving all persisted data into one file (SQLite database)

Refactor connection file logics into `kishu/storage/connection.py` and unit-test them separately.