### PR TITLE
Adjust kishu installation check and kishuboard makefile

### DIFF
--- a/kishuboard/Makefile
+++ b/kishuboard/Makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 
 NODE_INSTALLED=$(shell node -v > /dev/null 2>&1 && echo "yes")
-KISHU_INSTALLED=$(shell pip list | grep -w "^kishu" && echo "yes")
+KISHU_INSTALLED=$(shell pip list 2>&1 | grep -w "^kishu" > /dev/null && echo "yes")
 ENV_PREFIX=$(shell python -c "if __import__('pathlib').Path('.venv/bin/pip').exists(): print('.venv/bin/')")
 
 .PHONY: install_kishu
@@ -34,3 +34,14 @@ install_backend: install_kishu ## Install the Kishu board
 .PHONY: install
 install: install_frontend install_backend ## Install the frontend, backend, and Kishu board
 	@echo "Installation completed successfully."
+
+.PHONY: fmt
+fmt:              ## Format code using black & isort.
+	$(ENV_PREFIX)isort kishuboard/
+	$(ENV_PREFIX)black -l 127 kishuboard/
+
+.PHONY: lint
+lint:             ## Run pep8, black, mypy linters.
+	$(ENV_PREFIX)flake8 --extend-ignore=E203 --max-line-length 127 kishuboard/
+	$(ENV_PREFIX)black -l 127 --check kishuboard/
+	$(ENV_PREFIX)mypy --ignore-missing-imports kishuboard/

--- a/kishuboard/kishuboard/__init__.py
+++ b/kishuboard/kishuboard/__init__.py
@@ -5,5 +5,6 @@ except ImportError:
     # in editable mode with pip. It is highly recommended to install
     # the package from a stable release or in editable mode.
     import warnings
+
     warnings.warn("Importing 'kishuboard' outside a proper installation.")
     __version__ = "dev"

--- a/kishuboard/kishuboard/server.py
+++ b/kishuboard/kishuboard/server.py
@@ -1,33 +1,34 @@
 import json
 import os
+from typing import Optional
 
 from flask import Flask, request, send_from_directory
 from flask_cors import CORS
-from typing import Optional
-
 from kishu.commands import KishuCommand, into_json
 
 
 def is_true(s: str) -> bool:
     return s.lower() == "true"
 
+
 # Determine the directory of the current file (app.py)
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
 # Build the path to the static directory
-static_dir = os.path.join(current_dir, 'build')
+static_dir = os.path.join(current_dir, "build")
 
 app = Flask("kishu_server", static_folder=static_dir)
 CORS(app)
 
+
 # Serve React App (frontend endpoints)
-@app.route('/', defaults={'path': ''})
-@app.route('/<path:path>')
+@app.route("/", defaults={"path": ""})
+@app.route("/<path:path>")
 def serve(path):
-    if path != "" and os.path.exists(app.static_folder + '/' + path):
+    if path != "" and os.path.exists(app.static_folder + "/" + path):
         return send_from_directory(app.static_folder, path)
     else:
-        return send_from_directory(app.static_folder, 'index.html')
+        return send_from_directory(app.static_folder, "index.html")
 
 
 # Backend endpoints
@@ -93,7 +94,6 @@ def rename_branch(notebook_id: str, old_branch_name: str, new_branch_name: str) 
     return into_json(rename_branch_result)
 
 
-
 @app.get("/api/tag/<notebook_id>/<tag_name>")
 def tag(notebook_id: str, tag_name: str) -> str:
     commit_id: Optional[str] = request.args.get("commit_id", default=None, type=str)
@@ -101,7 +101,8 @@ def tag(notebook_id: str, tag_name: str) -> str:
     tag_result = KishuCommand.tag(notebook_id, tag_name, commit_id, message)
     return into_json(tag_result)
 
-#APIs that can only be used by the frontend to get information
+
+# APIs that can only be used by the frontend to get information
 @app.get("/api/delete_tag/<notebook_id>/<tag_name>")
 def delete_tag(notebook_id: str, tag_name: str) -> str:
     delete_tag_result = KishuCommand.delete_tag(notebook_id, tag_name)
@@ -148,6 +149,6 @@ def fe_edit_message(notebook_id: str, commit_id: str, new_message: str):
 def main() -> None:
     app.run(port=4999)
 
+
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
The original flag includes `grep` outputs, so it always triggers `kishu` installation.

Also add `fmt` and `lint` for Python files.