### PR TITLE
Support updating latest notebook state

### DIFF
--- a/kishu/kishu/storage/commit.py
+++ b/kishu/kishu/storage/commit.py
@@ -29,6 +29,22 @@ class CommitEntryKind(str, enum.Enum):
     manual = "manual"
 
 
+class NotebookCommitState(str, enum.Enum):
+    """State of notebook commit. The state machine diagram is as followed.
+
+    unspecified --> with_commit --> updated
+
+    unspecified: no notebook commit.
+    with_commit: the notebook is recorded at same time as commit creation.
+    amend_notebook: the notebook is separately amended to the commit.
+
+    """
+
+    unspecified = "unspecified"
+    with_commit = "with_commit"
+    amend_notebook = "amend_notebook"
+
+
 @dataclass
 class FormattedCell:
     cell_type: str
@@ -58,17 +74,25 @@ class CommitEntry:
     """
 
     commit_id: str = ""
-    kind: CommitEntryKind = CommitEntryKind.unspecified
-
-    checkpoint_runtime_s: Optional[float] = None
-    executed_cells: Optional[List[str]] = None
-    executed_outputs: Optional[Dict[int, str]] = None
-    raw_nb: Optional[str] = None
-    formatted_cells: Optional[List[FormattedCell]] = None
-    restore_plan: Optional[kishu.planning.plan.RestorePlan] = None
     message: str = ""
     timestamp: float = 0.0
+    kind: CommitEntryKind = CommitEntryKind.unspecified
+
+    # Execution state.
+    executed_cells: Optional[List[str]] = None
+    executed_outputs: Optional[Dict[int, str]] = None
+
+    # Notebook state.
+    raw_nb: Optional[str] = None
+    formatted_cells: Optional[List[FormattedCell]] = None
+    nb_record_type: NotebookCommitState = NotebookCommitState.unspecified
+
+    # Planner state.
+    restore_plan: Optional[kishu.planning.plan.RestorePlan] = None
     ahg_string: Optional[str] = None
+    checkpoint_runtime_s: Optional[float] = None
+
+    # Version hashes.
     code_version: int = 0
     varset_version: int = 0
 

--- a/kishu/tests/conftest.py
+++ b/kishu/tests/conftest.py
@@ -280,7 +280,6 @@ def basic_execution_ids(kishu_jupyter) -> Generator[List[str], None, None]:
     info = JupyterInfoMock(raw_cell="y = x + 1")
     kishu_jupyter.pre_run_cell(info)
     kishu_jupyter.post_run_cell(JupyterResultMock(info=info, execution_count=execution_count))
-    kishu_jupyter.wait_until_commit_finishes()
 
     yield ["0:0:1", "0:0:2", "0:0:3"]  # List of commit IDs
 

--- a/kishu/tests/test_commands.py
+++ b/kishu/tests/test_commands.py
@@ -16,7 +16,7 @@ from kishu.commands import (
 )
 from kishu.diff import CodeDiffHunk, VariableVersionCompare
 from kishu.jupyter.runtime import JupyterRuntimeEnv
-from kishu.jupyterint import CommitEntry, CommitEntryKind
+from kishu.jupyterint import CommitEntry, CommitEntryKind, NotebookCommitState
 from kishu.storage.branch import KishuBranch
 from kishu.storage.commit_graph import CommitNodeInfo
 from kishu.storage.path import KishuPath
@@ -138,6 +138,7 @@ class TestKishuCommand:
                 # "y = x + 1",
             ],
             executed_outputs={},
+            nb_record_type=NotebookCommitState.with_commit,
             message=status_result.commit_entry.message,  # Not tested,
             timestamp=status_result.commit_entry.timestamp,  # Not tested
             ahg_string=status_result.commit_entry.ahg_string,  # Not tested


### PR DESCRIPTION
Implement an API (`_kishu.update_latest_notebook`) to update the notebook information in the selected commit using the latest notebook state on file system.

Note: We still commit most fields in `commit / post_run_cell` to capture a complete state (especially, executed cell, execution errors, timestamp/duration, planner state) and ensure timing without further synchronization.