### PR TITLE
Disable History tracking in spawned InteractiveShells in RestorePlan

### DIFF
--- a/kishu/tests/planning/test_plan.py
+++ b/kishu/tests/planning/test_plan.py
@@ -143,8 +143,8 @@ class TestPlan:
             result_ns = restore_plans[i].run(db_path_name, exec_id)
             assert result_ns.to_dict() == user_ns.to_dict()
 
-        # There should be no leftover open files.
-        assert get_open_file_count() == num_open_files_before
+            # There should be no leftover open files.
+            assert get_open_file_count() == num_open_files_before
 
     def test_mix_reload_recompute_restore_plan(self, db_path_name, kishu_checkpoint):
         user_ns = Namespace({"a": 1, "b": 2})


### PR DESCRIPTION
Disable History tracking in spawned InteractiveShells in RestorePlan. This fixes [Bug: Too many open files #313](https://github.com/illinoisdata/kishu/issues/313) as the file handlers were caused by the InteractiveShells opening file handlers to a SQlite3 database for tracking history which weren't properly cleaned up.