### PR TITLE
Reset head state on re-attachment

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -321,6 +321,11 @@ class KishuForJupyter:
         self._kishu_nb_graph.init_database()
         self._kishu_variable_version.init_database()
 
+        # Always reset head.
+        self._kishu_branch.reset_head()
+        self._kishu_graph.reset()
+        self._kishu_nb_graph.reset()
+
         # For unit tests.
         if os.environ.get(KishuForJupyter.ENV_KISHU_TEST_MODE, False):
             self._test_mode = True

--- a/kishu/kishu/storage/branch.py
+++ b/kishu/kishu/storage/branch.py
@@ -189,6 +189,13 @@ class KishuBranch:
         finally:
             con.close()
 
+    def reset_head(self) -> None:
+        # Delete head to no-head state.
+        con = sqlite3.connect(self.database_path)
+        cur = con.cursor()
+        cur.execute(f"delete from {HEAD_BRANCH_TABLE} where head = '{HEAD_KEY}'")
+        con.commit()
+
     def update_head(
         self, branch_name: Optional[str] = None, commit_id: Optional[str] = None, is_detach: bool = False
     ) -> HeadBranch:

--- a/kishu/kishu/storage/commit_graph.py
+++ b/kishu/kishu/storage/commit_graph.py
@@ -129,6 +129,12 @@ class CommitGraphStore:
         finally:
             con.close()
 
+    def reset_head(self):
+        con = sqlite3.connect(self._database_path)
+        cur = con.cursor()
+        cur.execute(f"delete from {self._head_commit_table} where head = '{HEAD_KEY}'")
+        con.commit()
+
     def set_head(self, commit_id: CommitId):
         con = sqlite3.connect(self._database_path)
         cur = con.cursor()
@@ -224,3 +230,9 @@ class KishuCommitGraph:
         if commit_node_info is None:
             self._store.insert_parent(CommitNodeInfo(commit_id, ABSOLUTE_PAST))
         self._store.set_head(commit_id)
+
+    def reset(self) -> None:
+        """
+        Resets head to ABSOLUTE_PAST.
+        """
+        self._store.reset_head()


### PR DESCRIPTION
Previously we didn't reset the head state on re-attachment so the next commit after doing so would be a child of the previous head.

Here we always reset to absolute past