### PR TITLE
Fix boolean parsing in Kishu config

### DIFF
--- a/kishu/kishu/storage/config.py
+++ b/kishu/kishu/storage/config.py
@@ -94,10 +94,11 @@ class Config:
             return ast.literal_eval(Config.config[config_category][config_entry])
 
         # Direct casting of booleans (e.g., bool("False") == True) doesn't work; use a mapping.
-        if isinstance(default, bool) and config_entry in Config.config[config_category]:
+        elif isinstance(default, bool) and config_entry in Config.config[config_category]:
             return str_to_bool(Config.config[config_category][config_entry])
 
-        return type(default)(Config.config[config_category].get(config_entry, default))
+        else:
+            return type(default)(Config.config[config_category].get(config_entry, default))
 
     @staticmethod
     def set(config_category: str, config_entry: str, config_value: Any) -> None:

--- a/kishu/tests/storage/test_config.py
+++ b/kishu/tests/storage/test_config.py
@@ -126,7 +126,6 @@ def test_set_and_get_nonexistant_category():
 
 
 def test_backward_compatibility():
-    print(Config.CONFIG_PATH)
     # The config file should not exist before the first get call.
     assert not os.path.isfile(Config.CONFIG_PATH)
 
@@ -140,7 +139,6 @@ def test_backward_compatibility():
 
 
 def test_boolean_config():
-    print(Config.CONFIG_PATH)
     # The config file should not exist before the first get call.
     assert not os.path.isfile(Config.CONFIG_PATH)
 
@@ -148,6 +146,21 @@ def test_boolean_config():
     assert "always_migrate" not in Config.config["OPTIMIZER"]
     Config.set("OPTIMIZER", "always_migrate", False)
     assert not Config.get("OPTIMIZER", "always_migrate", True)
+
+    Config.set("OPTIMIZER", "always_migrate", 0)
+    assert not Config.get("OPTIMIZER", "always_migrate", True)
+
+    Config.set("OPTIMIZER", "always_migrate", "no")
+    assert not Config.get("OPTIMIZER", "always_migrate", True)
+
+    Config.set("OPTIMIZER", "always_migrate", True)
+    assert Config.get("OPTIMIZER", "always_migrate", False)
+
+    Config.set("OPTIMIZER", "always_migrate", 1)
+    assert Config.get("OPTIMIZER", "always_migrate", False)
+
+    Config.set("OPTIMIZER", "always_migrate", "yes")
+    assert Config.get("OPTIMIZER", "always_migrate", False)
 
     # Non-bools throw an error when parsed.
     Config.set("OPTIMIZER", "always_migrate", "ABC")


### PR DESCRIPTION
Fixed boolean parsing in Kishu config. Previously, boolean config flags could not be manually set to `False` due to string parsing, i.e., `bool('False')` evaluates to `True`. Fixed by introducing a mapping dictionary for strings to booleans.