### PR TITLE
Undo onto latest automatic commit

### DIFF
--- a/kishu/kishu/jupyterint.py
+++ b/kishu/kishu/jupyterint.py
@@ -596,6 +596,9 @@ class KishuForJupyter:
         return possible_commit_ids[0]
 
     def commit(self, message: Optional[str] = None) -> BareReprStr:
+        if self._commit_id_mode == "counter":
+            self._last_execution_count += 1
+
         # Save notebook on manual commit.
         self.save_notebook()
 


### PR DESCRIPTION
#419: undoing previously checks out the last commit, including manual commits which is confusing for the user.

With this change, undo would check out the latest automatic commit (made after each cell execution).
