### PR TITLE
Release to PyPI based on PR labels

### DIFF
--- a/.github/workflows/kishu.yml
+++ b/.github/workflows/kishu.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # python-version: ["3.8", "3.9", "3.10"]
         python-version: ["3.8"]
 
     steps:
@@ -27,7 +26,7 @@ jobs:
       run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  publish:
+    name: Publish Packages
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+
+    strategy:
+      matrix:
+        # Modules here must implement `make release` in their directory.
+        module: [kishu, jupyterlab_kishu, kishuboard]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Check for Label
+        id: check_label
+        run: |
+          LABELS="${{ toJson(github.event.pull_request.labels.*.name) }}"
+          if echo "$LABELS" | grep -qE "release-${{ matrix.module }}"; then
+            echo "Matching ${{ matrix.module }}-v label found"
+            echo "::set-output name=publish::true"
+          else
+            echo "No matching label, skipping publish"
+            echo "::set-output name=publish::false"
+          fi
+
+      - name: Set up Python
+        if: steps.check_label.outputs.publish == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install Dependencies
+        if: steps.check_label.outputs.publish == 'true'
+        run: pip install build twine
+
+      - name: Build and Publish to PyPI
+        if: steps.check_label.outputs.publish == 'true'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          cd ${{ matrix.module }}
+          make release

--- a/jupyterlab_kishu/.github/workflows/build.yml
+++ b/jupyterlab_kishu/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         architecture: 'x64'

--- a/jupyterlab_kishu/Makefile
+++ b/jupyterlab_kishu/Makefile
@@ -66,3 +66,9 @@ clean:            ## Clean unused files.
 	@rm -rf htmlcov
 	@rm -rf .tox/
 	@rm -rf docs/_build
+
+.PHONY: release
+release:          ## Build and upload to PyPI.
+	$(ENV_PREFIX)jlpm build
+	$(ENV_PREFIX)python -m build
+	$(ENV_PREFIX)twine upload dist/*

--- a/kishu/Makefile
+++ b/kishu/Makefile
@@ -58,3 +58,8 @@ clean:            ## Clean unused files.
 	@rm -rf htmlcov
 	@rm -rf .tox/
 	@rm -rf docs/_build
+
+.PHONY: release
+release:          ## Build and upload to PyPI.
+	$(ENV_PREFIX)python -m build
+	$(ENV_PREFIX)twine upload dist/*

--- a/kishuboard/Makefile
+++ b/kishuboard/Makefile
@@ -45,3 +45,10 @@ lint:             ## Run pep8, black, mypy linters.
 	$(ENV_PREFIX)flake8 --extend-ignore=E203 --max-line-length 127 kishuboard/
 	$(ENV_PREFIX)black -l 127 --check kishuboard/
 	$(ENV_PREFIX)mypy --ignore-missing-imports kishuboard/
+
+.PHONY: release
+release:          ## Build and upload to PyPI.
+	npm install
+	npm run build
+	$(ENV_PREFIX)python -m build
+	$(ENV_PREFIX)twine upload dist/*


### PR DESCRIPTION
On `main` push, when the PR has a label of the form `release-kishu` or `release-jupyterlab_kishu` or `release-kishuboard`, this workflow would build and upload the respective module to PyPI.

It also works with multiple tags at a time.

#416 