### PR TITLE
Include kishu submodules in package configuration

### DIFF
--- a/kishu/pyproject.toml
+++ b/kishu/pyproject.toml
@@ -7,7 +7,12 @@ kishu = ["py.typed"]
 
 [tool.setuptools]
 # package-dir = { "" = "kishu" }
-packages = ["kishu"]
+packages = [
+    "kishu",
+    "kishu.jupyter",
+    "kishu.planning",
+    "kishu.storage",
+]
 
 [project]
 name = "kishu"


### PR DESCRIPTION
To address these warnings during release:
```
/tmp/build-env-n5yprk88/lib/python3.8/site-packages/setuptools/command/build_py.py:220: _Warning: Package 'kishu.jupyter' is absent from the `packages` configuration.
!!
...
```