### PR TITLE
Release jupyterlab_kishu-v0.3.1 (retry)

### DIFF
--- a/jupyterlab_kishu/package.json
+++ b/jupyterlab_kishu/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab_kishu",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "A JupyterLab extension to interact with Kishu.",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
The previous release failed because the version wasn't bumped.

Addressed for future by documenting this process in #425 