### PR TITLE
Specify cap for jupyter-ui-poll version

### DIFF
--- a/jupyterlab_kishu/pyproject.toml
+++ b/jupyterlab_kishu/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
     "jupyterlab",
-    "jupyter-ui-poll<=1.0.0",
     "jupyter_server",
     "tornado",
     "kishu",

--- a/jupyterlab_kishu/pyproject.toml
+++ b/jupyterlab_kishu/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyterlab",
+    "jupyter-ui-poll<=1.0.0",
     "jupyter_server",
     "tornado",
     "kishu",

--- a/kishu/kishu/__init__.py
+++ b/kishu/kishu/__init__.py
@@ -1,5 +1,5 @@
 __app_name__ = "kishu"
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 # This allows `%load_ext kishu` in Jupyter.
 # Then, `%lsmagic` includes kishu functions.

--- a/kishu/pyproject.toml
+++ b/kishu/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-version = "0.3.3"  # README: Keep in sync with kishu/__init__.py
+version = "0.3.4"  # README: Keep in sync with kishu/__init__.py
 dependencies = [  # README: Keep in sync with requirements.txt
     # Core
     "dataclasses",
@@ -50,7 +50,7 @@ dependencies = [  # README: Keep in sync with requirements.txt
     "dill",
     "ipykernel",
     "ipylab",
-    "jupyter_ui_poll",
+    "jupyter_ui_poll<=1.0.0",
     "loguru",
     "nbconvert",
     "nbformat",

--- a/kishu/requirements.txt
+++ b/kishu/requirements.txt
@@ -7,7 +7,7 @@ dataclasses_json
 dill
 ipykernel
 ipylab
-jupyter_ui_poll
+jupyter_ui_poll<=1.0.0
 loguru
 nbconvert
 nbformat


### PR DESCRIPTION
The latest jupyter-ui-poll==1.1.0 update (https://pypi.org/project/jupyter-ui-poll/1.1.0/) breaks Kishu by making cell executions hang indefinitely in sessions with Kishu attached.